### PR TITLE
[fluxgate] Release/0.3.0

### DIFF
--- a/fluxgate-control-support/pom.xml
+++ b/fluxgate-control-support/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-control-support</artifactId>

--- a/fluxgate-core/pom.xml
+++ b/fluxgate-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-core</artifactId>

--- a/fluxgate-core/src/main/java/org/fluxgate/core/context/RequestContext.java
+++ b/fluxgate-core/src/main/java/org/fluxgate/core/context/RequestContext.java
@@ -7,6 +7,15 @@ import java.util.Map;
 /**
  * Represents contextual information about the incoming request. This allows custom KeyResolvers and
  * strategies to determine which rate-limit bucket should be used.
+ *
+ * <p>Contains request metadata for rate limiting decisions and event tracking:
+ *
+ * <ul>
+ *   <li>Client identification: IP, userId, apiKey
+ *   <li>Request info: endpoint, method
+ *   <li>HTTP headers: collected in headers map
+ *   <li>Custom attributes: extensible key-value pairs
+ * </ul>
  */
 public final class RequestContext {
 
@@ -16,6 +25,10 @@ public final class RequestContext {
   private final String endpoint;
   private final String method;
 
+  /** HTTP request headers (e.g., User-Agent, Referer, X-Request-Id). */
+  private final Map<String, String> headers;
+
+  /** Custom attributes for user-defined metadata. */
   private final Map<String, Object> attributes;
 
   private RequestContext(Builder builder) {
@@ -24,76 +37,325 @@ public final class RequestContext {
     this.apiKey = builder.apiKey;
     this.endpoint = builder.endpoint;
     this.method = builder.method;
+    this.headers = Collections.unmodifiableMap(new HashMap<>(builder.headers));
     this.attributes = Collections.unmodifiableMap(new HashMap<>(builder.attributes));
   }
 
+  /**
+   * Returns the client IP address.
+   *
+   * @return the client IP address, may be null
+   */
   public String getClientIp() {
     return clientIp;
   }
 
+  /**
+   * Returns the user ID.
+   *
+   * @return the user ID, may be null
+   */
   public String getUserId() {
     return userId;
   }
 
+  /**
+   * Returns the API key.
+   *
+   * @return the API key, may be null
+   */
   public String getApiKey() {
     return apiKey;
   }
 
+  /**
+   * Returns the request endpoint path.
+   *
+   * @return the endpoint path, may be null
+   */
   public String getEndpoint() {
     return endpoint;
   }
 
+  /**
+   * Returns the HTTP method.
+   *
+   * @return the HTTP method (GET, POST, etc.), may be null
+   */
   public String getMethod() {
     return method;
   }
 
+  /**
+   * Returns all HTTP headers collected from the request.
+   *
+   * @return unmodifiable map of header names to values
+   */
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+
+  /**
+   * Returns a specific HTTP header value.
+   *
+   * @param name the header name (case-sensitive as stored)
+   * @return the header value, or null if not present
+   */
+  public String getHeader(String name) {
+    return headers.get(name);
+  }
+
+  /**
+   * Returns custom attributes for user-defined metadata.
+   *
+   * @return unmodifiable map of attributes
+   */
   public Map<String, Object> getAttributes() {
     return attributes;
   }
 
+  /**
+   * Returns a specific attribute value.
+   *
+   * @param key the attribute key
+   * @return the attribute value, or null if not present
+   */
+  public Object getAttribute(String key) {
+    return attributes.get(key);
+  }
+
+  /**
+   * Creates a new Builder instance.
+   *
+   * @return a new Builder
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /** Builder for creating RequestContext instances. */
   public static final class Builder {
     private String clientIp;
     private String userId;
     private String apiKey;
     private String endpoint;
     private String method;
-
+    private final Map<String, String> headers = new HashMap<>();
     private final Map<String, Object> attributes = new HashMap<>();
 
+    /** Creates a new Builder instance. */
+    public Builder() {
+      // Default constructor
+    }
+
+    // =========================================================================
+    // Setters
+    // =========================================================================
+
+    /**
+     * Sets the client IP address.
+     *
+     * @param clientIp the client IP address
+     * @return this builder
+     */
     public Builder clientIp(String clientIp) {
       this.clientIp = clientIp;
       return this;
     }
 
+    /**
+     * Sets the user ID.
+     *
+     * @param userId the user ID
+     * @return this builder
+     */
     public Builder userId(String userId) {
       this.userId = userId;
       return this;
     }
 
+    /**
+     * Sets the API key.
+     *
+     * @param apiKey the API key
+     * @return this builder
+     */
     public Builder apiKey(String apiKey) {
       this.apiKey = apiKey;
       return this;
     }
 
+    /**
+     * Sets the request endpoint path.
+     *
+     * @param endpoint the endpoint path
+     * @return this builder
+     */
     public Builder endpoint(String endpoint) {
       this.endpoint = endpoint;
       return this;
     }
 
+    /**
+     * Sets the HTTP method.
+     *
+     * @param method the HTTP method
+     * @return this builder
+     */
     public Builder method(String method) {
       this.method = method;
       return this;
     }
 
+    /**
+     * Adds a single HTTP header.
+     *
+     * @param name the header name
+     * @param value the header value (null values are ignored)
+     * @return this builder
+     */
+    public Builder header(String name, String value) {
+      if (value != null) {
+        this.headers.put(name, value);
+      }
+      return this;
+    }
+
+    /**
+     * Adds multiple HTTP headers at once.
+     *
+     * @param headers map of header names to values (null values are ignored)
+     * @return this builder
+     */
+    public Builder headers(Map<String, String> headers) {
+      if (headers != null) {
+        headers.forEach(
+            (k, v) -> {
+              if (v != null) {
+                this.headers.put(k, v);
+              }
+            });
+      }
+      return this;
+    }
+
+    /**
+     * Adds a custom attribute.
+     *
+     * @param key the attribute key
+     * @param value the attribute value
+     * @return this builder
+     */
     public Builder attribute(String key, Object value) {
       this.attributes.put(key, value);
       return this;
     }
 
+    /**
+     * Adds multiple custom attributes at once.
+     *
+     * @param attributes map of attribute keys to values
+     * @return this builder
+     */
+    public Builder attributes(Map<String, Object> attributes) {
+      if (attributes != null) {
+        this.attributes.putAll(attributes);
+      }
+      return this;
+    }
+
+    // =========================================================================
+    // Getters - for use in RequestContextCustomizer
+    // =========================================================================
+
+    /**
+     * Returns the current clientIp value.
+     *
+     * @return the client IP address
+     */
+    public String getClientIp() {
+      return clientIp;
+    }
+
+    /**
+     * Returns the current userId value.
+     *
+     * @return the user ID
+     */
+    public String getUserId() {
+      return userId;
+    }
+
+    /**
+     * Returns the current apiKey value.
+     *
+     * @return the API key
+     */
+    public String getApiKey() {
+      return apiKey;
+    }
+
+    /**
+     * Returns the current endpoint value.
+     *
+     * @return the endpoint path
+     */
+    public String getEndpoint() {
+      return endpoint;
+    }
+
+    /**
+     * Returns the current method value.
+     *
+     * @return the HTTP method
+     */
+    public String getMethod() {
+      return method;
+    }
+
+    /**
+     * Returns the current headers map (modifiable).
+     *
+     * @return the headers map
+     */
+    public Map<String, String> getHeaders() {
+      return headers;
+    }
+
+    /**
+     * Returns a specific header value.
+     *
+     * @param name the header name
+     * @return the header value, or null if not present
+     */
+    public String getHeader(String name) {
+      return headers.get(name);
+    }
+
+    /**
+     * Returns the current attributes map (modifiable).
+     *
+     * @return the attributes map
+     */
+    public Map<String, Object> getAttributes() {
+      return attributes;
+    }
+
+    /**
+     * Returns a specific attribute value.
+     *
+     * @param key the attribute key
+     * @return the attribute value, or null if not present
+     */
+    public Object getAttribute(String key) {
+      return attributes.get(key);
+    }
+
+    /**
+     * Builds and returns a new RequestContext instance.
+     *
+     * @return a new RequestContext
+     */
     public RequestContext build() {
       return new RequestContext(this);
     }

--- a/fluxgate-core/src/main/java/org/fluxgate/core/key/KeyResolver.java
+++ b/fluxgate-core/src/main/java/org/fluxgate/core/key/KeyResolver.java
@@ -1,7 +1,34 @@
 package org.fluxgate.core.key;
 
+import org.fluxgate.core.config.RateLimitRule;
 import org.fluxgate.core.context.RequestContext;
 
+/**
+ * Resolves the rate limit key from the request context and rule configuration.
+ *
+ * <p>The key determines which bucket to use for rate limiting. The resolution is based on the
+ * rule's {@link org.fluxgate.core.config.LimitScope}:
+ *
+ * <ul>
+ *   <li>{@code GLOBAL} - Single bucket for all requests (uses ruleSetId)
+ *   <li>{@code PER_IP} - One bucket per client IP address
+ *   <li>{@code PER_USER} - One bucket per user ID
+ *   <li>{@code PER_API_KEY} - One bucket per API key
+ *   <li>{@code CUSTOM} - Custom resolution via attributes
+ * </ul>
+ *
+ * <p>Users can customize the key resolution by providing their own {@link KeyResolver}
+ * implementation and setting the appropriate values in {@link RequestContext} via a
+ * RequestContextCustomizer (in fluxgate-spring-boot-starter module).
+ */
 public interface KeyResolver {
-  RateLimitKey resolve(RequestContext context);
+
+  /**
+   * Resolves the rate limit key for the given request context and rule.
+   *
+   * @param context the request context containing client information (IP, userId, apiKey, etc.)
+   * @param rule the rate limit rule containing the LimitScope
+   * @return the resolved rate limit key
+   */
+  RateLimitKey resolve(RequestContext context, RateLimitRule rule);
 }

--- a/fluxgate-core/src/main/java/org/fluxgate/core/key/LimitScopeKeyResolver.java
+++ b/fluxgate-core/src/main/java/org/fluxgate/core/key/LimitScopeKeyResolver.java
@@ -1,0 +1,136 @@
+package org.fluxgate.core.key;
+
+import org.fluxgate.core.config.LimitScope;
+import org.fluxgate.core.config.RateLimitRule;
+import org.fluxgate.core.context.RequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default {@link KeyResolver} implementation that resolves keys based on the rule's {@link
+ * LimitScope}.
+ *
+ * <p>This resolver uses the following mapping:
+ *
+ * <table border="1">
+ *   <caption>LimitScope to Key Mapping</caption>
+ *   <tr><th>LimitScope</th><th>Key Source</th><th>Example Key</th></tr>
+ *   <tr><td>GLOBAL</td><td>ruleSetId</td><td>"global"</td></tr>
+ *   <tr><td>PER_IP</td><td>RequestContext.clientIp</td><td>"192.168.1.100"</td></tr>
+ *   <tr><td>PER_USER</td><td>RequestContext.userId</td><td>"user-123"</td></tr>
+ *   <tr><td>PER_API_KEY</td><td>RequestContext.apiKey</td><td>"api-key-abc"</td></tr>
+ *   <tr><td>CUSTOM</td><td>attributes.get(keyStrategyId)</td><td>"custom-value"</td></tr>
+ * </table>
+ *
+ * <p>For CUSTOM scope, the resolver looks up the value from RequestContext attributes using the
+ * rule's keyStrategyId as the attribute key.
+ *
+ * <p><b>Fallback behavior:</b> If the expected value is null or empty, the resolver falls back to
+ * clientIp to prevent null keys.
+ *
+ * <p><b>Usage example:</b>
+ *
+ * <pre>{@code
+ * // Create resolver
+ * KeyResolver resolver = new LimitScopeKeyResolver();
+ *
+ * // Use in RuleSetProvider
+ * RateLimitRuleSet.builder(ruleSetId)
+ *     .keyResolver(resolver)
+ *     .rules(rules)
+ *     .build();
+ * }</pre>
+ *
+ * @see KeyResolver
+ * @see LimitScope
+ */
+public class LimitScopeKeyResolver implements KeyResolver {
+
+  private static final Logger log = LoggerFactory.getLogger(LimitScopeKeyResolver.class);
+
+  /** Default key used when no specific key can be resolved. */
+  private static final String GLOBAL_KEY = "global";
+
+  @Override
+  public RateLimitKey resolve(RequestContext context, RateLimitRule rule) {
+    LimitScope scope = rule.getScope();
+    if (scope == null) {
+      scope = LimitScope.PER_IP; // default
+    }
+
+    String keyValue =
+        switch (scope) {
+          case GLOBAL -> GLOBAL_KEY;
+          case PER_IP -> resolveClientIp(context);
+          case PER_USER -> resolveUserId(context);
+          case PER_API_KEY -> resolveApiKey(context);
+          case CUSTOM -> resolveCustom(context, rule);
+        };
+
+    log.debug("Resolved key for rule {} with scope {}: {}", rule.getId(), scope, keyValue);
+
+    return new RateLimitKey(keyValue);
+  }
+
+  // TODO: Consider alternative strategies when clientIp is null/empty:
+  //  - Option 1: Reject immediately (strict, may block valid requests)
+  //  - Option 2: Bypass rate limiting (permissive, potential security risk)
+  //  - Option 3: Generate unique key per request (effectively no limit)
+  //  - Option 4: Use Resilience4j fallback mechanism
+  //  Current behavior: All requests with unknown IP share the same bucket,
+  //  which will quickly hit the rate limit. This is a conservative approach.
+  private String resolveClientIp(RequestContext context) {
+    String clientIp = context.getClientIp();
+    if (clientIp == null || clientIp.isEmpty()) {
+      log.warn("clientIp is null/empty, using 'unknown' as fallback");
+      return "unknown";
+    }
+    return clientIp;
+  }
+
+  private String resolveUserId(RequestContext context) {
+    String userId = context.getUserId();
+    if (userId == null || userId.isEmpty()) {
+      log.warn(
+          "userId is null/empty for PER_USER scope, falling back to clientIp: {}",
+          context.getClientIp());
+      return resolveClientIp(context);
+    }
+    return userId;
+  }
+
+  private String resolveApiKey(RequestContext context) {
+    String apiKey = context.getApiKey();
+    if (apiKey == null || apiKey.isEmpty()) {
+      log.warn(
+          "apiKey is null/empty for PER_API_KEY scope, falling back to clientIp: {}",
+          context.getClientIp());
+      return resolveClientIp(context);
+    }
+    return apiKey;
+  }
+
+  private String resolveCustom(RequestContext context, RateLimitRule rule) {
+    String keyStrategyId = rule.getKeyStrategyId();
+    if (keyStrategyId == null || keyStrategyId.isEmpty()) {
+      log.warn("keyStrategyId is null/empty for CUSTOM scope, falling back to clientIp");
+      return resolveClientIp(context);
+    }
+
+    Object value = context.getAttributes().get(keyStrategyId);
+    if (value == null) {
+      log.warn(
+          "Attribute '{}' not found in context for CUSTOM scope, falling back to clientIp",
+          keyStrategyId);
+      return resolveClientIp(context);
+    }
+
+    String stringValue = value.toString();
+    if (stringValue.isEmpty()) {
+      log.warn("Attribute '{}' is empty for CUSTOM scope, falling back to clientIp", keyStrategyId);
+      return resolveClientIp(context);
+    }
+
+    return stringValue;
+  }
+}

--- a/fluxgate-core/src/main/java/org/fluxgate/core/spi/RateLimitRuleSetProvider.java
+++ b/fluxgate-core/src/main/java/org/fluxgate/core/spi/RateLimitRuleSetProvider.java
@@ -3,11 +3,20 @@ package org.fluxgate.core.spi;
 import java.util.Optional;
 import org.fluxgate.core.ratelimiter.RateLimitRuleSet;
 
+/**
+ * Service Provider Interface for loading RateLimitRuleSet instances.
+ *
+ * <p>Implementations may load rule sets from various sources such as MongoDB, YAML files,
+ * databases, or in-memory configurations.
+ */
 public interface RateLimitRuleSetProvider {
 
   /**
    * Returns a RateLimitRuleSet for the given id. Implementations may load from Mongo, YAML, DB,
    * etc.
+   *
+   * @param ruleSetId the unique identifier for the rule set
+   * @return an Optional containing the RateLimitRuleSet if found, or empty if not found
    */
   Optional<RateLimitRuleSet> findById(String ruleSetId);
 }

--- a/fluxgate-core/src/test/java/org/fluxgate/core/FeatureDemoTest.java
+++ b/fluxgate-core/src/test/java/org/fluxgate/core/FeatureDemoTest.java
@@ -42,7 +42,7 @@ class FeatureDemoTest {
             .addBand(band)
             .build();
 
-    KeyResolver ipResolver = ctx -> RateLimitKey.of("ip:" + ctx.getClientIp());
+    KeyResolver ipResolver = (ctx, r) -> RateLimitKey.of("ip:" + ctx.getClientIp());
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("ip-limiter")
@@ -83,7 +83,7 @@ class FeatureDemoTest {
             .addBand(band)
             .build();
 
-    KeyResolver apiKeyResolver = ctx -> RateLimitKey.of("apikey:" + ctx.getApiKey());
+    KeyResolver apiKeyResolver = (ctx, r) -> RateLimitKey.of("apikey:" + ctx.getApiKey());
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("apikey-limiter")
@@ -130,7 +130,7 @@ class FeatureDemoTest {
     RateLimitRule rule =
         RateLimitRule.builder("multi-band").addBand(shortBand).addBand(longBand).build();
 
-    KeyResolver resolver = ctx -> RateLimitKey.of("user:" + ctx.getUserId());
+    KeyResolver resolver = (ctx, r) -> RateLimitKey.of("user:" + ctx.getUserId());
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("multi-band-limiter")
@@ -171,7 +171,7 @@ class FeatureDemoTest {
     RateLimitRule rule =
         RateLimitRule.builder("user-limit").scope(LimitScope.PER_USER).addBand(band).build();
 
-    KeyResolver userResolver = ctx -> RateLimitKey.of("user:" + ctx.getUserId());
+    KeyResolver userResolver = (ctx, r) -> RateLimitKey.of("user:" + ctx.getUserId());
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("user-limiter")
@@ -215,7 +215,7 @@ class FeatureDemoTest {
     RateLimitRule rule =
         RateLimitRule.builder("global-limit").scope(LimitScope.GLOBAL).addBand(band).build();
 
-    KeyResolver globalResolver = ctx -> RateLimitKey.of("global");
+    KeyResolver globalResolver = (ctx, r) -> RateLimitKey.of("global");
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("global-limiter")
@@ -277,7 +277,7 @@ class FeatureDemoTest {
 
     RateLimitRule rule = RateLimitRule.builder("metric-test").addBand(band).build();
 
-    KeyResolver resolver = ctx -> RateLimitKey.of("ip:" + ctx.getClientIp());
+    KeyResolver resolver = (ctx, r) -> RateLimitKey.of("ip:" + ctx.getClientIp());
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("metric-limiter")
@@ -312,7 +312,7 @@ class FeatureDemoTest {
 
     // Composite key strategy: region + userId
     KeyResolver customResolver =
-        ctx -> {
+        (ctx, r) -> {
           String region = (String) ctx.getAttributes().get("region");
           String userId = ctx.getUserId();
           return RateLimitKey.of(region + ":" + userId);
@@ -365,7 +365,7 @@ class FeatureDemoTest {
 
     RateLimitRule rule = RateLimitRule.builder("bulk-limit").addBand(band).build();
 
-    KeyResolver resolver = ctx -> RateLimitKey.of("user:" + ctx.getUserId());
+    KeyResolver resolver = (ctx, r) -> RateLimitKey.of("user:" + ctx.getUserId());
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("bulk-limiter").rules(List.of(rule)).keyResolver(resolver).build();
@@ -403,7 +403,7 @@ class FeatureDemoTest {
 
     RateLimitRule rule = RateLimitRule.builder("wait-test").addBand(band).build();
 
-    KeyResolver resolver = ctx -> RateLimitKey.of("test");
+    KeyResolver resolver = (ctx, r) -> RateLimitKey.of("test");
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("wait-limiter").rules(List.of(rule)).keyResolver(resolver).build();
@@ -437,7 +437,7 @@ class FeatureDemoTest {
     RateLimitRule rule =
         RateLimitRule.builder("info-test").name("Information Test Rule").addBand(band).build();
 
-    KeyResolver resolver = ctx -> RateLimitKey.of("test-key");
+    KeyResolver resolver = (ctx, r) -> RateLimitKey.of("test-key");
 
     RateLimitRuleSet ruleSet =
         RateLimitRuleSet.builder("info-limiter").rules(List.of(rule)).keyResolver(resolver).build();

--- a/fluxgate-core/src/test/java/org/fluxgate/core/MultiLevelRateLimitTest.java
+++ b/fluxgate-core/src/test/java/org/fluxgate/core/MultiLevelRateLimitTest.java
@@ -45,7 +45,7 @@ class MultiLevelRateLimitTest {
             .addBand(ipBand)
             .build();
 
-    KeyResolver ipResolver = ctx -> RateLimitKey.of("ip:" + ctx.getClientIp());
+    KeyResolver ipResolver = (ctx, r) -> RateLimitKey.of("ip:" + ctx.getClientIp());
 
     RateLimitRuleSet ipRuleSet =
         RateLimitRuleSet.builder("ip-limiter")
@@ -67,7 +67,7 @@ class MultiLevelRateLimitTest {
             .addBand(serviceBand)
             .build();
 
-    KeyResolver serviceResolver = ctx -> RateLimitKey.of("service:" + ctx.getApiKey());
+    KeyResolver serviceResolver = (ctx, r) -> RateLimitKey.of("service:" + ctx.getApiKey());
 
     RateLimitRuleSet serviceRuleSet =
         RateLimitRuleSet.builder("service-limiter")
@@ -140,7 +140,7 @@ class MultiLevelRateLimitTest {
         RateLimitBand.builder(Duration.ofMinutes(1), 5).label("IP-1min-5req").build();
 
     RateLimitRule ipRule = RateLimitRule.builder("ip-limit").addBand(ipBand).build();
-    KeyResolver ipResolver = ctx -> RateLimitKey.of("ip:" + ctx.getClientIp());
+    KeyResolver ipResolver = (ctx, r) -> RateLimitKey.of("ip:" + ctx.getClientIp());
 
     RateLimitRuleSet ipRuleSet =
         RateLimitRuleSet.builder("ip-limiter")
@@ -153,7 +153,7 @@ class MultiLevelRateLimitTest {
         RateLimitBand.builder(Duration.ofMinutes(10), 20).label("Service-10min-20req").build();
 
     RateLimitRule serviceRule = RateLimitRule.builder("service-limit").addBand(serviceBand).build();
-    KeyResolver serviceResolver = ctx -> RateLimitKey.of("service:" + ctx.getApiKey());
+    KeyResolver serviceResolver = (ctx, r) -> RateLimitKey.of("service:" + ctx.getApiKey());
 
     RateLimitRuleSet serviceRuleSet =
         RateLimitRuleSet.builder("service-limiter")
@@ -196,7 +196,7 @@ class MultiLevelRateLimitTest {
         RateLimitBand.builder(Duration.ofMinutes(1), 100).label("IP-1min-100req").build();
 
     RateLimitRule ipRule = RateLimitRule.builder("ip-limit").addBand(ipBand).build();
-    KeyResolver ipResolver = ctx -> RateLimitKey.of("ip:" + ctx.getClientIp());
+    KeyResolver ipResolver = (ctx, r) -> RateLimitKey.of("ip:" + ctx.getClientIp());
 
     RateLimitRuleSet ipRuleSet =
         RateLimitRuleSet.builder("ip-limiter")
@@ -211,7 +211,7 @@ class MultiLevelRateLimitTest {
             .build();
 
     RateLimitRule serviceRule = RateLimitRule.builder("service-limit").addBand(serviceBand).build();
-    KeyResolver serviceResolver = ctx -> RateLimitKey.of("service:" + ctx.getApiKey());
+    KeyResolver serviceResolver = (ctx, r) -> RateLimitKey.of("service:" + ctx.getApiKey());
 
     RateLimitRuleSet serviceRuleSet =
         RateLimitRuleSet.builder("service-limiter")

--- a/fluxgate-core/src/test/java/org/fluxgate/core/RateLimitEngineTest.java
+++ b/fluxgate-core/src/test/java/org/fluxgate/core/RateLimitEngineTest.java
@@ -122,7 +122,7 @@ class RateLimitEngineTest {
     private StubRuleSetProvider(String expectedId) {
       this.expectedId = expectedId;
 
-      KeyResolver keyResolver = context -> RateLimitKey.of("stub");
+      KeyResolver keyResolver = (context, rule) -> RateLimitKey.of("stub");
 
       RateLimitBand dummyBand =
           RateLimitBand.builder(java.time.Duration.ofMinutes(1), 100).label("dummy-band").build();

--- a/fluxgate-core/src/test/java/org/fluxgate/core/bucket/Bucket4jRateLimiterTest.java
+++ b/fluxgate-core/src/test/java/org/fluxgate/core/bucket/Bucket4jRateLimiterTest.java
@@ -63,7 +63,7 @@ class Bucket4jRateLimiterTest {
   @Test
   void should_allow_within_capacity_and_reject_after() {
     // given
-    KeyResolver keyResolver = ctx -> ipKey(ctx.getClientIp());
+    KeyResolver keyResolver = (ctx, rule) -> ipKey(ctx.getClientIp());
     RateLimitRuleSet ruleSet = createSimpleRuleSet(keyResolver, null);
 
     RequestContext ctx = createRequestContext("127.0.0.1", "user-1");
@@ -88,7 +88,7 @@ class Bucket4jRateLimiterTest {
   @Test
   void differentKeysShouldHaveIndependentBuckets() {
     // given
-    KeyResolver keyResolver = ctx -> ipKey(ctx.getClientIp());
+    KeyResolver keyResolver = (ctx, rule) -> ipKey(ctx.getClientIp());
     RateLimitRuleSet ruleSet = createSimpleRuleSet(keyResolver, null);
 
     RequestContext ip1 = createRequestContext("10.0.0.1", "user-1");
@@ -122,7 +122,7 @@ class Bucket4jRateLimiterTest {
           lastRecorded.set(result);
         };
 
-    KeyResolver keyResolver = ctx -> ipKey(ctx.getClientIp());
+    KeyResolver keyResolver = (ctx, rule) -> ipKey(ctx.getClientIp());
     RateLimitRuleSet ruleSet = createSimpleRuleSet(keyResolver, recorder);
     RequestContext ctx = createRequestContext("192.168.0.10", "user-123");
 

--- a/fluxgate-core/src/test/java/org/fluxgate/core/context/RequestContextTest.java
+++ b/fluxgate-core/src/test/java/org/fluxgate/core/context/RequestContextTest.java
@@ -2,6 +2,7 @@ package org.fluxgate.core.context;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -324,6 +325,271 @@ class RequestContextTest {
       // then
       assertEquals("acme-corp", context.getAttributes().get("tenantId"));
       assertEquals("premium", context.getAttributes().get("subscriptionTier"));
+    }
+  }
+
+  // ==================== Headers Tests ====================
+
+  @Nested
+  @DisplayName("Headers Tests")
+  class HeadersTests {
+
+    @Test
+    @DisplayName("should add single header")
+    void header_shouldAddSingleHeader() {
+      // given / when
+      RequestContext context = RequestContext.builder().header("User-Agent", "Mozilla/5.0").build();
+
+      // then
+      assertEquals("Mozilla/5.0", context.getHeader("User-Agent"));
+      assertEquals(1, context.getHeaders().size());
+    }
+
+    @Test
+    @DisplayName("should add multiple headers")
+    void header_shouldAddMultipleHeaders() {
+      // given / when
+      RequestContext context =
+          RequestContext.builder()
+              .header("User-Agent", "Mozilla/5.0")
+              .header("Accept", "application/json")
+              .header("X-Request-Id", "req-123")
+              .build();
+
+      // then
+      assertEquals(3, context.getHeaders().size());
+      assertEquals("Mozilla/5.0", context.getHeader("User-Agent"));
+      assertEquals("application/json", context.getHeader("Accept"));
+      assertEquals("req-123", context.getHeader("X-Request-Id"));
+    }
+
+    @Test
+    @DisplayName("should add headers from map")
+    void headers_shouldAddHeadersFromMap() {
+      // given
+      Map<String, String> headerMap = new HashMap<>();
+      headerMap.put("User-Agent", "TestAgent");
+      headerMap.put("Accept-Language", "en-US");
+
+      // when
+      RequestContext context = RequestContext.builder().headers(headerMap).build();
+
+      // then
+      assertEquals(2, context.getHeaders().size());
+      assertEquals("TestAgent", context.getHeader("User-Agent"));
+      assertEquals("en-US", context.getHeader("Accept-Language"));
+    }
+
+    @Test
+    @DisplayName("should ignore null header values")
+    void header_shouldIgnoreNullValues() {
+      // given / when
+      RequestContext context =
+          RequestContext.builder()
+              .header("User-Agent", "Mozilla/5.0")
+              .header("X-Null-Header", null)
+              .build();
+
+      // then
+      assertEquals(1, context.getHeaders().size());
+      assertNull(context.getHeader("X-Null-Header"));
+    }
+
+    @Test
+    @DisplayName("should ignore null values in headers map")
+    void headers_shouldIgnoreNullValuesInMap() {
+      // given
+      Map<String, String> headerMap = new HashMap<>();
+      headerMap.put("User-Agent", "TestAgent");
+      headerMap.put("X-Null", null);
+
+      // when
+      RequestContext context = RequestContext.builder().headers(headerMap).build();
+
+      // then
+      assertEquals(1, context.getHeaders().size());
+      assertEquals("TestAgent", context.getHeader("User-Agent"));
+    }
+
+    @Test
+    @DisplayName("should handle null headers map")
+    void headers_shouldHandleNullMap() {
+      // given / when
+      RequestContext context = RequestContext.builder().headers(null).build();
+
+      // then
+      assertNotNull(context.getHeaders());
+      assertTrue(context.getHeaders().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should return null for non-existent header")
+    void getHeader_shouldReturnNullForNonExistentHeader() {
+      // given
+      RequestContext context = RequestContext.builder().build();
+
+      // then
+      assertNull(context.getHeader("Non-Existent"));
+    }
+
+    @Test
+    @DisplayName("headers map should be unmodifiable")
+    void getHeaders_shouldReturnUnmodifiableMap() {
+      // given
+      RequestContext context = RequestContext.builder().header("Test", "value").build();
+
+      // when / then
+      assertThrows(
+          UnsupportedOperationException.class, () -> context.getHeaders().put("New", "value"));
+    }
+  }
+
+  // ==================== Builder Getters Tests ====================
+
+  @Nested
+  @DisplayName("Builder Getters Tests")
+  class BuilderGettersTests {
+
+    @Test
+    @DisplayName("builder should provide getter for clientIp")
+    void builder_shouldProvideGetterForClientIp() {
+      // given
+      RequestContext.Builder builder = RequestContext.builder().clientIp("192.168.1.1");
+
+      // then
+      assertEquals("192.168.1.1", builder.getClientIp());
+    }
+
+    @Test
+    @DisplayName("builder should provide getter for userId")
+    void builder_shouldProvideGetterForUserId() {
+      // given
+      RequestContext.Builder builder = RequestContext.builder().userId("user-123");
+
+      // then
+      assertEquals("user-123", builder.getUserId());
+    }
+
+    @Test
+    @DisplayName("builder should provide getter for apiKey")
+    void builder_shouldProvideGetterForApiKey() {
+      // given
+      RequestContext.Builder builder = RequestContext.builder().apiKey("api-key-xyz");
+
+      // then
+      assertEquals("api-key-xyz", builder.getApiKey());
+    }
+
+    @Test
+    @DisplayName("builder should provide getter for endpoint")
+    void builder_shouldProvideGetterForEndpoint() {
+      // given
+      RequestContext.Builder builder = RequestContext.builder().endpoint("/api/test");
+
+      // then
+      assertEquals("/api/test", builder.getEndpoint());
+    }
+
+    @Test
+    @DisplayName("builder should provide getter for method")
+    void builder_shouldProvideGetterForMethod() {
+      // given
+      RequestContext.Builder builder = RequestContext.builder().method("POST");
+
+      // then
+      assertEquals("POST", builder.getMethod());
+    }
+
+    @Test
+    @DisplayName("builder should provide getter for headers")
+    void builder_shouldProvideGetterForHeaders() {
+      // given
+      RequestContext.Builder builder =
+          RequestContext.builder()
+              .header("User-Agent", "Mozilla/5.0")
+              .header("Accept", "application/json");
+
+      // then
+      assertEquals(2, builder.getHeaders().size());
+      assertEquals("Mozilla/5.0", builder.getHeader("User-Agent"));
+      assertEquals("application/json", builder.getHeader("Accept"));
+    }
+
+    @Test
+    @DisplayName("builder should provide getter for attributes")
+    void builder_shouldProvideGetterForAttributes() {
+      // given
+      RequestContext.Builder builder =
+          RequestContext.builder().attribute("tenantId", "tenant-123").attribute("region", "us");
+
+      // then
+      assertEquals(2, builder.getAttributes().size());
+      assertEquals("tenant-123", builder.getAttribute("tenantId"));
+      assertEquals("us", builder.getAttribute("region"));
+    }
+
+    @Test
+    @DisplayName("builder headers map should be modifiable")
+    void builder_headersShouldBeModifiable() {
+      // given
+      RequestContext.Builder builder = RequestContext.builder().header("Test", "value");
+
+      // when - modify through getter
+      builder.getHeaders().put("New", "newValue");
+      builder.getHeaders().remove("Test");
+
+      // then
+      RequestContext context = builder.build();
+      assertEquals("newValue", context.getHeader("New"));
+      assertNull(context.getHeader("Test"));
+    }
+
+    @Test
+    @DisplayName("builder attributes map should be modifiable")
+    void builder_attributesShouldBeModifiable() {
+      // given
+      RequestContext.Builder builder = RequestContext.builder().attribute("key", "value");
+
+      // when - modify through getter
+      builder.getAttributes().put("new", "newValue");
+      builder.getAttributes().remove("key");
+
+      // then
+      RequestContext context = builder.build();
+      assertEquals("newValue", context.getAttribute("new"));
+      assertNull(context.getAttribute("key"));
+    }
+  }
+
+  // ==================== getAttribute Tests ====================
+
+  @Nested
+  @DisplayName("getAttribute Tests")
+  class GetAttributeTests {
+
+    @Test
+    @DisplayName("getAttribute should return correct value")
+    void getAttribute_shouldReturnCorrectValue() {
+      // given
+      RequestContext context =
+          RequestContext.builder()
+              .attribute("stringAttr", "value")
+              .attribute("intAttr", 42)
+              .build();
+
+      // then
+      assertEquals("value", context.getAttribute("stringAttr"));
+      assertEquals(42, context.getAttribute("intAttr"));
+    }
+
+    @Test
+    @DisplayName("getAttribute should return null for non-existent key")
+    void getAttribute_shouldReturnNullForNonExistentKey() {
+      // given
+      RequestContext context = RequestContext.builder().build();
+
+      // then
+      assertNull(context.getAttribute("non-existent"));
     }
   }
 

--- a/fluxgate-core/src/test/java/org/fluxgate/core/handler/RateLimitResponseTest.java
+++ b/fluxgate-core/src/test/java/org/fluxgate/core/handler/RateLimitResponseTest.java
@@ -2,6 +2,7 @@ package org.fluxgate.core.handler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.fluxgate.core.config.OnLimitExceedPolicy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -235,6 +236,104 @@ class RateLimitResponseTest {
 
       // then
       assertEquals(-1, response.getRetryAfterMillis());
+    }
+  }
+
+  // ==================== OnLimitExceedPolicy Tests ====================
+
+  @Nested
+  @DisplayName("OnLimitExceedPolicy Tests")
+  class OnLimitExceedPolicyTests {
+
+    @Test
+    @DisplayName("rejected() without policy should default to REJECT_REQUEST")
+    void rejected_shouldDefaultToRejectRequestPolicy() {
+      // given / when
+      RateLimitResponse response = RateLimitResponse.rejected(1000);
+
+      // then
+      assertEquals(OnLimitExceedPolicy.REJECT_REQUEST, response.getOnLimitExceedPolicy());
+    }
+
+    @Test
+    @DisplayName("rejected() with WAIT_FOR_REFILL policy should set policy correctly")
+    void rejected_shouldSetWaitForRefillPolicy() {
+      // given / when
+      RateLimitResponse response =
+          RateLimitResponse.rejected(1000, OnLimitExceedPolicy.WAIT_FOR_REFILL);
+
+      // then
+      assertEquals(OnLimitExceedPolicy.WAIT_FOR_REFILL, response.getOnLimitExceedPolicy());
+    }
+
+    @Test
+    @DisplayName("rejected() with REJECT_REQUEST policy should set policy correctly")
+    void rejected_shouldSetRejectRequestPolicy() {
+      // given / when
+      RateLimitResponse response =
+          RateLimitResponse.rejected(1000, OnLimitExceedPolicy.REJECT_REQUEST);
+
+      // then
+      assertEquals(OnLimitExceedPolicy.REJECT_REQUEST, response.getOnLimitExceedPolicy());
+    }
+
+    @Test
+    @DisplayName("allowed() should have null policy")
+    void allowed_shouldHaveNullPolicy() {
+      // given / when
+      RateLimitResponse response = RateLimitResponse.allowed(100, 0);
+
+      // then
+      assertNull(response.getOnLimitExceedPolicy());
+    }
+  }
+
+  // ==================== shouldWaitForRefill Tests ====================
+
+  @Nested
+  @DisplayName("shouldWaitForRefill Tests")
+  class ShouldWaitForRefillTests {
+
+    @Test
+    @DisplayName("shouldWaitForRefill() should return true for rejected with WAIT_FOR_REFILL")
+    void shouldWaitForRefill_shouldReturnTrueForWaitPolicy() {
+      // given / when
+      RateLimitResponse response =
+          RateLimitResponse.rejected(1000, OnLimitExceedPolicy.WAIT_FOR_REFILL);
+
+      // then
+      assertTrue(response.shouldWaitForRefill());
+    }
+
+    @Test
+    @DisplayName("shouldWaitForRefill() should return false for rejected with REJECT_REQUEST")
+    void shouldWaitForRefill_shouldReturnFalseForRejectPolicy() {
+      // given / when
+      RateLimitResponse response =
+          RateLimitResponse.rejected(1000, OnLimitExceedPolicy.REJECT_REQUEST);
+
+      // then
+      assertFalse(response.shouldWaitForRefill());
+    }
+
+    @Test
+    @DisplayName("shouldWaitForRefill() should return false for allowed response")
+    void shouldWaitForRefill_shouldReturnFalseForAllowedResponse() {
+      // given / when
+      RateLimitResponse response = RateLimitResponse.allowed(100, 0);
+
+      // then
+      assertFalse(response.shouldWaitForRefill());
+    }
+
+    @Test
+    @DisplayName("shouldWaitForRefill() should return false for rejected without policy (null)")
+    void shouldWaitForRefill_shouldReturnFalseForNullPolicy() {
+      // given / when - using the simple rejected() which defaults to REJECT_REQUEST
+      RateLimitResponse response = RateLimitResponse.rejected(1000);
+
+      // then
+      assertFalse(response.shouldWaitForRefill());
     }
   }
 

--- a/fluxgate-core/src/test/java/org/fluxgate/core/reload/CachingRuleSetProviderTest.java
+++ b/fluxgate-core/src/test/java/org/fluxgate/core/reload/CachingRuleSetProviderTest.java
@@ -98,7 +98,7 @@ class CachingRuleSetProviderTest {
     RateLimitRule rule = RateLimitRule.builder("rule-1").addBand(band).build();
     return RateLimitRuleSet.builder(id)
         .rules(List.of(rule))
-        .keyResolver(ctx -> new RateLimitKey(ctx.getClientIp()))
+        .keyResolver((ctx, r) -> new RateLimitKey(ctx.getClientIp()))
         .build();
   }
 

--- a/fluxgate-mongo-adapter/pom.xml
+++ b/fluxgate-mongo-adapter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-mongo-adapter</artifactId>

--- a/fluxgate-mongo-adapter/src/main/java/org/fluxgate/adapter/mongo/event/MongoRateLimitMetricsRecorder.java
+++ b/fluxgate-mongo-adapter/src/main/java/org/fluxgate/adapter/mongo/event/MongoRateLimitMetricsRecorder.java
@@ -2,12 +2,32 @@ package org.fluxgate.adapter.mongo.event;
 
 import com.mongodb.client.MongoCollection;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import org.bson.Document;
+import org.fluxgate.core.config.OnLimitExceedPolicy;
 import org.fluxgate.core.context.RequestContext;
 import org.fluxgate.core.metrics.RateLimitMetricsRecorder;
 import org.fluxgate.core.ratelimiter.RateLimitResult;
 
+/**
+ * MongoDB implementation of RateLimitMetricsRecorder.
+ *
+ * <p>Stores rate limit events with comprehensive tracking information including:
+ *
+ * <ul>
+ *   <li>Rate limit decision details (allowed, tokens, policy)
+ *   <li>Request metadata (endpoint, method)
+ *   <li>Client identification (IP, userId, apiKey)
+ *   <li>HTTP headers (collected in headers subdocument)
+ *   <li>Custom attributes
+ * </ul>
+ */
 public class MongoRateLimitMetricsRecorder implements RateLimitMetricsRecorder {
+
+  private static final DateTimeFormatter ISO_FORMATTER =
+      DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC);
 
   private final MongoCollection<Document> eventCollection;
 
@@ -17,27 +37,92 @@ public class MongoRateLimitMetricsRecorder implements RateLimitMetricsRecorder {
 
   @Override
   public void record(RequestContext context, RateLimitResult result) {
+    Instant now = Instant.now();
 
+    // Extract rule information
     String ruleSetId = null;
     String ruleId = null;
+    String ruleName = null;
+    String onLimitExceedPolicy = null;
+    String keyStrategyId = null;
+
     if (result.getMatchedRule() != null) {
       ruleSetId = result.getMatchedRule().getRuleSetIdOrNull();
-      ruleId = result.getMatchedRule().getId(); // Omit or adjust if this method doesn't exist
+      ruleId = result.getMatchedRule().getId();
+      ruleName = result.getMatchedRule().getName();
+      keyStrategyId = result.getMatchedRule().getKeyStrategyId();
+
+      OnLimitExceedPolicy policy = result.getMatchedRule().getOnLimitExceedPolicy();
+      if (policy != null) {
+        onLimitExceedPolicy = policy.name();
+      }
     }
 
+    // Build event document with comprehensive tracking info
     Document doc =
         new Document()
-            .append("timestamp", Instant.now().toEpochMilli())
+            // Timestamp information
+            .append("timestamp", now.toEpochMilli())
+            .append("timestampIso", ISO_FORMATTER.format(now))
+
+            // Rate limit decision
             .append("allowed", result.isAllowed())
             .append("remainingTokens", result.getRemainingTokens())
             .append("nanosToWaitForRefill", result.getNanosToWaitForRefill())
+            .append("retryAfterMs", result.getNanosToWaitForRefill() / 1_000_000)
+
+            // Rule information
             .append("ruleSetId", ruleSetId)
             .append("ruleId", ruleId)
+            .append("ruleName", ruleName)
+            .append("onLimitExceedPolicy", onLimitExceedPolicy)
+            .append("keyStrategyId", keyStrategyId)
+
+            // Request information
             .append("endpoint", context.getEndpoint())
             .append("method", context.getMethod())
+
+            // Client identification
             .append("clientIp", context.getClientIp())
-            .append("attributes", context.getAttributes());
+            .append("userId", context.getUserId())
+            .append("apiKey", context.getApiKey())
+
+            // HTTP headers (as subdocument)
+            .append("headers", convertHeaders(context.getHeaders()))
+
+            // Custom attributes
+            .append("attributes", convertAttributes(context.getAttributes()));
 
     eventCollection.insertOne(doc);
+  }
+
+  /** Converts headers map to BSON Document. */
+  private Document convertHeaders(Map<String, String> headers) {
+    if (headers == null || headers.isEmpty()) {
+      return new Document();
+    }
+    Document doc = new Document();
+    headers.forEach(
+        (key, value) -> {
+          if (value != null) {
+            doc.append(key, value);
+          }
+        });
+    return doc;
+  }
+
+  /** Converts attributes map to BSON Document. */
+  private Document convertAttributes(Map<String, Object> attributes) {
+    if (attributes == null || attributes.isEmpty()) {
+      return new Document();
+    }
+    Document doc = new Document();
+    attributes.forEach(
+        (key, value) -> {
+          if (value != null) {
+            doc.append(key, value);
+          }
+        });
+    return doc;
   }
 }

--- a/fluxgate-mongo-adapter/src/main/java/org/fluxgate/adapter/mongo/rule/MongoRuleSetProvider.java
+++ b/fluxgate-mongo-adapter/src/main/java/org/fluxgate/adapter/mongo/rule/MongoRuleSetProvider.java
@@ -39,8 +39,8 @@ public class MongoRuleSetProvider implements RateLimitRuleSetProvider {
   /**
    * Creates a MongoRuleSetProvider without metrics recording.
    *
-   * @param ruleRepository repository for rate limit rules
-   * @param keyResolver resolver for generating rate limit keys
+   * @param ruleRepository repository for fetching rate limit rules
+   * @param keyResolver resolver for generating rate limit keys from request context
    */
   public MongoRuleSetProvider(RateLimitRuleRepository ruleRepository, KeyResolver keyResolver) {
     this(ruleRepository, keyResolver, null);
@@ -49,9 +49,9 @@ public class MongoRuleSetProvider implements RateLimitRuleSetProvider {
   /**
    * Creates a MongoRuleSetProvider with optional metrics recording.
    *
-   * @param ruleRepository repository for rate limit rules
-   * @param keyResolver resolver for generating rate limit keys
-   * @param metricsRecorder optional recorder for metrics (null to disable)
+   * @param ruleRepository repository for fetching rate limit rules
+   * @param keyResolver resolver for generating rate limit keys from request context
+   * @param metricsRecorder optional recorder for logging rate limit events (can be null)
    */
   public MongoRuleSetProvider(
       RateLimitRuleRepository ruleRepository,

--- a/fluxgate-mongo-adapter/src/test/java/org/fluxgate/adapter/mongo/MongoRuleSetProviderIntegrationTest.java
+++ b/fluxgate-mongo-adapter/src/test/java/org/fluxgate/adapter/mongo/MongoRuleSetProviderIntegrationTest.java
@@ -451,7 +451,7 @@ class MongoRuleSetProviderIntegrationTest {
   private static class TestKeyResolver implements KeyResolver {
 
     @Override
-    public RateLimitKey resolve(RequestContext context) {
+    public RateLimitKey resolve(RequestContext context, RateLimitRule rule) {
       return new RateLimitKey("test-key");
     }
   }

--- a/fluxgate-mongo-adapter/src/test/java/org/fluxgate/adapter/mongo/config/FluxgateMongoConfigTest.java
+++ b/fluxgate-mongo-adapter/src/test/java/org/fluxgate/adapter/mongo/config/FluxgateMongoConfigTest.java
@@ -82,7 +82,7 @@ class FluxgateMongoConfigTest {
   void ruleSetProvider_shouldCreateRuleSetProvider() {
     // given
     when(mongoDatabase.getCollection("rules")).thenReturn(ruleCollection);
-    KeyResolver keyResolver = context -> new RateLimitKey(context.getClientIp());
+    KeyResolver keyResolver = (context, rule) -> new RateLimitKey(context.getClientIp());
 
     // when
     RateLimitRuleSetProvider provider = config.ruleSetProvider(keyResolver);

--- a/fluxgate-mongo-adapter/src/test/java/org/fluxgate/adapter/mongo/converter/RateLimitRuleMongoConverterTest.java
+++ b/fluxgate-mongo-adapter/src/test/java/org/fluxgate/adapter/mongo/converter/RateLimitRuleMongoConverterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import org.bson.Document;
 import org.fluxgate.adapter.mongo.model.RateLimitBandDocument;
 import org.fluxgate.adapter.mongo.model.RateLimitRuleDocument;
@@ -307,5 +308,257 @@ class RateLimitRuleMongoConverterTest {
       // then
       assertEquals(scope, convertedRule.getScope(), "Scope " + scope + " should be preserved");
     }
+  }
+
+  @Test
+  @DisplayName("Should handle attributes in Domain to DTO conversion")
+  void toDto_shouldPreserveAttributes() {
+    // given
+    RateLimitRule rule =
+        RateLimitRule.builder("attrs-rule")
+            .name("Attributes Rule")
+            .enabled(true)
+            .scope(LimitScope.PER_IP)
+            .keyStrategyId("ip")
+            .onLimitExceedPolicy(OnLimitExceedPolicy.REJECT_REQUEST)
+            .addBand(RateLimitBand.builder(Duration.ofSeconds(1), 100).label("test").build())
+            .ruleSetId("attrs-ruleset")
+            .attribute("tier", "premium")
+            .attribute("team", "billing")
+            .build();
+
+    // when
+    RateLimitRuleDocument dto = RateLimitRuleMongoConverter.toDto(rule);
+
+    // then
+    assertEquals("premium", dto.getAttributes().get("tier"));
+    assertEquals("billing", dto.getAttributes().get("team"));
+  }
+
+  @Test
+  @DisplayName("Should handle attributes in DTO to Domain conversion")
+  void toDomain_shouldPreserveAttributes() {
+    // given
+    RateLimitBandDocument bandDto = new RateLimitBandDocument(1L, 100L, "test");
+    RateLimitRuleDocument dto =
+        new RateLimitRuleDocument(
+            "attrs-rule",
+            "Attributes Rule",
+            true,
+            LimitScope.PER_IP,
+            "ip",
+            OnLimitExceedPolicy.REJECT_REQUEST,
+            List.of(bandDto),
+            "attrs-ruleset",
+            Map.of("customField", "customValue", "priority", 1));
+
+    // when
+    RateLimitRule rule = RateLimitRuleMongoConverter.toDomain(dto);
+
+    // then
+    assertEquals("customValue", rule.getAttribute("customField"));
+    assertEquals(1, rule.getAttribute("priority"));
+  }
+
+  @Test
+  @DisplayName("Should handle empty attributes in toDomain")
+  void toDomain_shouldHandleEmptyAttributes() {
+    // given
+    RateLimitBandDocument bandDto = new RateLimitBandDocument(1L, 100L, "test");
+    RateLimitRuleDocument dto =
+        new RateLimitRuleDocument(
+            "empty-attrs-rule",
+            "Empty Attributes Rule",
+            true,
+            LimitScope.PER_IP,
+            "ip",
+            OnLimitExceedPolicy.REJECT_REQUEST,
+            List.of(bandDto),
+            "empty-attrs-ruleset",
+            Map.of()); // empty attributes
+
+    // when
+    RateLimitRule rule = RateLimitRuleMongoConverter.toDomain(dto);
+
+    // then
+    assertNotNull(rule.getAttributes());
+  }
+
+  @Test
+  @DisplayName("Should handle null attributes in toDomain")
+  void toDomain_shouldHandleNullAttributes() {
+    // given
+    RateLimitBandDocument bandDto = new RateLimitBandDocument(1L, 100L, "test");
+    RateLimitRuleDocument dto =
+        new RateLimitRuleDocument(
+            "null-attrs-rule",
+            "Null Attributes Rule",
+            true,
+            LimitScope.PER_IP,
+            "ip",
+            OnLimitExceedPolicy.REJECT_REQUEST,
+            List.of(bandDto),
+            "null-attrs-ruleset",
+            null); // null attributes
+
+    // when
+    RateLimitRule rule = RateLimitRuleMongoConverter.toDomain(dto);
+
+    // then
+    assertNotNull(rule);
+  }
+
+  @Test
+  @DisplayName("Should include attributes in BSON conversion")
+  void toBson_shouldIncludeAttributes() {
+    // given
+    RateLimitBandDocument bandDto = new RateLimitBandDocument(1L, 100L, "test");
+    RateLimitRuleDocument dto =
+        new RateLimitRuleDocument(
+            "bson-attrs-rule",
+            "BSON Attributes Rule",
+            true,
+            LimitScope.PER_IP,
+            "ip",
+            OnLimitExceedPolicy.REJECT_REQUEST,
+            List.of(bandDto),
+            "bson-attrs-ruleset",
+            Map.of("region", "us-east-1"));
+
+    // when
+    Document bson = RateLimitRuleMongoConverter.toBson(dto);
+
+    // then
+    Document attrs = bson.get("attributes", Document.class);
+    assertNotNull(attrs);
+    assertEquals("us-east-1", attrs.getString("region"));
+  }
+
+  @Test
+  @DisplayName("Should not include attributes in BSON when empty")
+  void toBson_shouldNotIncludeEmptyAttributes() {
+    // given
+    RateLimitBandDocument bandDto = new RateLimitBandDocument(1L, 100L, "test");
+    RateLimitRuleDocument dto =
+        new RateLimitRuleDocument(
+            "no-attrs-rule",
+            "No Attributes Rule",
+            true,
+            LimitScope.PER_IP,
+            "ip",
+            OnLimitExceedPolicy.REJECT_REQUEST,
+            List.of(bandDto),
+            "no-attrs-ruleset",
+            Map.of()); // empty
+
+    // when
+    Document bson = RateLimitRuleMongoConverter.toBson(dto);
+
+    // then
+    assertFalse(bson.containsKey("attributes"), "Empty attributes should not be in BSON");
+  }
+
+  @Test
+  @DisplayName("Should parse attributes from BSON")
+  void fromBson_shouldParseAttributes() {
+    // given
+    Document bandBson =
+        new Document().append("windowSeconds", 1L).append("capacity", 100L).append("label", "test");
+
+    Document attrsBson = new Document().append("env", "production").append("version", 2);
+
+    Document bson =
+        new Document()
+            .append("id", "parse-attrs-rule")
+            .append("name", "Parse Attributes Rule")
+            .append("enabled", true)
+            .append("scope", "PER_IP")
+            .append("keyStrategyId", "ip")
+            .append("onLimitExceedPolicy", "REJECT_REQUEST")
+            .append("ruleSetId", "parse-attrs-ruleset")
+            .append("bands", List.of(bandBson))
+            .append("attributes", attrsBson);
+
+    // when
+    RateLimitRuleDocument dto = RateLimitRuleMongoConverter.fromBson(bson);
+
+    // then
+    assertEquals("production", dto.getAttributes().get("env"));
+    assertEquals(2, dto.getAttributes().get("version"));
+  }
+
+  @Test
+  @DisplayName("Should handle missing attributes in BSON")
+  void fromBson_shouldHandleMissingAttributes() {
+    // given
+    Document bandBson =
+        new Document().append("windowSeconds", 1L).append("capacity", 100L).append("label", "test");
+
+    Document bson =
+        new Document()
+            .append("id", "missing-attrs-rule")
+            .append("name", "Missing Attributes Rule")
+            .append("enabled", true)
+            .append("scope", "PER_IP")
+            .append("keyStrategyId", "ip")
+            .append("onLimitExceedPolicy", "REJECT_REQUEST")
+            .append("ruleSetId", "missing-attrs-ruleset")
+            .append("bands", List.of(bandBson));
+    // No attributes field
+
+    // when
+    RateLimitRuleDocument dto = RateLimitRuleMongoConverter.fromBson(bson);
+
+    // then
+    assertNotNull(dto.getAttributes());
+    assertTrue(dto.getAttributes().isEmpty());
+  }
+
+  @Test
+  @DisplayName("Should handle null bands in fromBson")
+  void fromBson_shouldHandleNullBands() {
+    // given
+    Document bson =
+        new Document()
+            .append("id", "null-bands-rule")
+            .append("name", "Null Bands Rule")
+            .append("enabled", true)
+            .append("scope", "PER_IP")
+            .append("keyStrategyId", "ip")
+            .append("onLimitExceedPolicy", "REJECT_REQUEST")
+            .append("ruleSetId", "null-bands-ruleset")
+            .append("bands", null); // null bands
+
+    // when
+    RateLimitRuleDocument dto = RateLimitRuleMongoConverter.fromBson(bson);
+
+    // then
+    assertNotNull(dto);
+    assertTrue(dto.getBands().isEmpty());
+  }
+
+  @Test
+  @DisplayName("Should use default enabled value when missing in BSON")
+  void fromBson_shouldUseDefaultEnabledWhenMissing() {
+    // given
+    Document bandBson =
+        new Document().append("windowSeconds", 1L).append("capacity", 100L).append("label", "test");
+
+    Document bson =
+        new Document()
+            .append("id", "default-enabled-rule")
+            .append("name", "Default Enabled Rule")
+            // no "enabled" field
+            .append("scope", "PER_IP")
+            .append("keyStrategyId", "ip")
+            .append("onLimitExceedPolicy", "REJECT_REQUEST")
+            .append("ruleSetId", "default-enabled-ruleset")
+            .append("bands", List.of(bandBson));
+
+    // when
+    RateLimitRuleDocument dto = RateLimitRuleMongoConverter.fromBson(bson);
+
+    // then
+    assertTrue(dto.isEnabled(), "Default enabled value should be true");
   }
 }

--- a/fluxgate-redis-ratelimiter/pom.xml
+++ b/fluxgate-redis-ratelimiter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-redis-ratelimiter</artifactId>

--- a/fluxgate-redis-ratelimiter/src/test/java/org/fluxgate/redis/RedisRateLimiterTest.java
+++ b/fluxgate-redis-ratelimiter/src/test/java/org/fluxgate/redis/RedisRateLimiterTest.java
@@ -10,8 +10,7 @@ import org.fluxgate.core.config.OnLimitExceedPolicy;
 import org.fluxgate.core.config.RateLimitBand;
 import org.fluxgate.core.config.RateLimitRule;
 import org.fluxgate.core.context.RequestContext;
-import org.fluxgate.core.key.KeyResolver;
-import org.fluxgate.core.key.RateLimitKey;
+import org.fluxgate.core.key.LimitScopeKeyResolver;
 import org.fluxgate.core.ratelimiter.RateLimitResult;
 import org.fluxgate.core.ratelimiter.RateLimitRuleSet;
 import org.fluxgate.redis.config.RedisRateLimiterConfig;
@@ -124,10 +123,8 @@ class RedisRateLimiterTest {
             .ruleSetId(ruleSetId)
             .build();
 
-    KeyResolver ipKeyResolver = context -> new RateLimitKey(context.getClientIp());
-
     return RateLimitRuleSet.builder(ruleSetId)
-        .keyResolver(ipKeyResolver)
+        .keyResolver(new LimitScopeKeyResolver())
         .rules(List.of(rule))
         .build();
   }

--- a/fluxgate-samples/fluxgate-sample-api/pom.xml
+++ b/fluxgate-samples/fluxgate-sample-api/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate-samples</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-sample-api</artifactId>

--- a/fluxgate-samples/fluxgate-sample-filter/pom.xml
+++ b/fluxgate-samples/fluxgate-sample-filter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate-samples</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-sample-filter</artifactId>

--- a/fluxgate-samples/fluxgate-sample-filter/src/main/java/org/fluxgate/sample/filter/config/RuleSetConfig.java
+++ b/fluxgate-samples/fluxgate-sample-filter/src/main/java/org/fluxgate/sample/filter/config/RuleSetConfig.java
@@ -53,7 +53,7 @@ public class RuleSetConfig {
         }
 
         // KeyResolver that extracts client IP
-        KeyResolver ipKeyResolver = context -> {
+        KeyResolver ipKeyResolver = (context, rule) -> {
             String ip = context.getClientIp();
             return new RateLimitKey(ip != null ? ip : "unknown");
         };

--- a/fluxgate-samples/fluxgate-sample-mongo/pom.xml
+++ b/fluxgate-samples/fluxgate-sample-mongo/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate-samples</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-sample-mongo</artifactId>

--- a/fluxgate-samples/fluxgate-sample-redis/pom.xml
+++ b/fluxgate-samples/fluxgate-sample-redis/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate-samples</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-sample-redis</artifactId>

--- a/fluxgate-samples/fluxgate-sample-redis/src/main/java/org/fluxgate/sample/redis/config/DynamicRuleSetProvider.java
+++ b/fluxgate-samples/fluxgate-sample-redis/src/main/java/org/fluxgate/sample/redis/config/DynamicRuleSetProvider.java
@@ -7,8 +7,7 @@ import org.fluxgate.core.config.LimitScope;
 import org.fluxgate.core.config.OnLimitExceedPolicy;
 import org.fluxgate.core.config.RateLimitBand;
 import org.fluxgate.core.config.RateLimitRule;
-import org.fluxgate.core.key.KeyResolver;
-import org.fluxgate.core.key.RateLimitKey;
+import org.fluxgate.core.key.LimitScopeKeyResolver;
 import org.fluxgate.core.ratelimiter.RateLimitRuleSet;
 import org.fluxgate.core.spi.RateLimitRuleSetProvider;
 import org.fluxgate.redis.store.RedisRuleSetStore;
@@ -114,15 +113,9 @@ public class DynamicRuleSetProvider implements RateLimitRuleSetProvider {
                     .build())
             .build();
 
-    KeyResolver keyResolver =
-        context -> {
-          String ip = context.getClientIp();
-          return new RateLimitKey(ip != null ? ip : "unknown");
-        };
-
     return RateLimitRuleSet.builder(data.getRuleSetId())
         .rules(List.of(rule))
-        .keyResolver(keyResolver)
+        .keyResolver(new LimitScopeKeyResolver())
         .build();
   }
 }

--- a/fluxgate-samples/fluxgate-sample-standalone/README.md
+++ b/fluxgate-samples/fluxgate-sample-standalone/README.md
@@ -5,9 +5,12 @@ A complete standalone application demonstrating FluxGate with direct MongoDB and
 ## Overview
 
 This sample showcases:
-- Direct MongoDB connection for rule storage (no external control-plane)
-- Direct Redis connection for rate limiting (no external data-plane)
-- `@EnableFluxgateFilter` for automatic HTTP filter integration
+- Direct MongoDB connection for rule storage
+- Direct Redis connection for rate limiting
+- **Multiple rate limit filters with different rule sets**
+- **LimitScope-based key resolution** (PER_IP, PER_USER, PER_API_KEY, CUSTOM)
+- **Composite key support** (IP + User ID combination)
+- **RequestContext customization** for IP override and attribute injection
 - Runtime rule management via REST API
 
 ## Prerequisites
@@ -31,7 +34,6 @@ docker run -d --name redis -p 6379:6379 redis:latest
 ## Running the Application
 
 ```bash
-# From the project root directory
 ./mvnw spring-boot:run -pl fluxgate-samples/fluxgate-sample-standalone
 ```
 
@@ -39,35 +41,56 @@ The application starts on port **8085**.
 
 ## API Endpoints
 
+### Rule Management APIs
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/admin/ruleset` | Create rate limit ruleset (10 req/min) |
-| GET | `/api/admin/ruleset` | Get current ruleset configuration |
-| POST | `/api/admin/sync` | Sync rules to Redis |
-| GET | `/api/test` | Rate-limited test endpoint |
+| POST | `/api/admin/rules/standalone` | Create rule for /api/test (10 req/min, PER_IP) |
+| POST | `/api/admin/rules/multi-filter` | Create 2 rules for /api/test/multi-filter |
+| POST | `/api/admin/rules/composite` | Create rule for /api/test/composite (10 req/min, IP+User) |
+| GET | `/api/admin/rules/{ruleSetId}` | Get rules by rule set ID |
 
-## Usage Example
+### Test Endpoints
 
-### Step 1: Create Rate Limit Rules
+| Method | Endpoint | RuleSet | LimitScope | Limits |
+|--------|----------|---------|------------|--------|
+| GET | `/api/test` | standalone-rules | PER_IP | 10 req/min |
+| GET | `/api/test/multi-filter` | multi-filter-rules | PER_IP | 10 + 20 req/min |
+| GET | `/api/test/composite` | composite-key-rules | CUSTOM (ipUser) | 10 req/min per IP+User |
+| GET | `/api/test/info` | - | - | Shows configuration |
+
+## Quick Start
+
+### Step 1: Create All Rules
 
 ```bash
-curl -X POST http://localhost:8085/api/admin/ruleset
+curl -X POST http://localhost:8085/api/admin/rules/all | jq
 ```
 
 Response:
 ```json
 {
   "success": true,
-  "ruleSetId": "standalone-rules",
-  "ruleId": "rate-limit-rule-1",
-  "limit": "10 requests per minute per IP"
+  "ruleSets": {
+    "standalone-rules": {
+      "endpoint": "/api/test",
+      "rules": 1,
+      "limit": "10 req/min"
+    },
+    "multi-filter-rules": {
+      "endpoint": "/api/test/multi-filter",
+      "rules": 2,
+      "limits": "10 req/min + 20 req/min"
+    }
+  },
+  "totalRules": 3
 }
 ```
 
-### Step 2: Test Rate Limiting
+### Step 2: Test Standalone Endpoint (10 req/min)
 
 ```bash
-# Send 12 requests
+# Send 12 requests - first 10 succeed, last 2 get 429
 for i in {1..12}; do
   echo -n "Request $i: "
   curl -s -o /dev/null -w "%{http_code}" http://localhost:8085/api/test
@@ -75,49 +98,266 @@ for i in {1..12}; do
 done
 ```
 
-Expected output:
+Expected:
 ```
-Request 1: 200
-Request 2: 200
-...
-Request 10: 200
-Request 11: 429
-Request 12: 429
+Request 1-10: 200
+Request 11-12: 429
 ```
 
-### Step 3: Check Current Rules
+### Step 3: Test Multi-Filter Endpoint (10 req/min + 20 req/min)
 
 ```bash
-curl http://localhost:8085/api/admin/ruleset | jq
+# Send 12 requests - rule1 (10 req/min) will trigger first
+for i in {1..12}; do
+  echo -n "Request $i: "
+  curl -s -o /dev/null -w "%{http_code}" http://localhost:8085/api/test/multi-filter
+  echo ""
+done
+```
+
+Expected (rule1 triggers at 11th request):
+```
+Request 1-10: 200
+Request 11-12: 429
+```
+
+Note: Both rules apply. Since rule1 (10 req/min) is stricter than rule2 (20 req/min), rule1 triggers first.
+
+### Step 4: Test Composite Key Endpoint (IP + User)
+
+```bash
+# Create the composite key rule
+curl -X POST http://localhost:8085/api/admin/rules/composite | jq
+
+# User A - gets 10 requests
+for i in {1..12}; do
+  echo -n "User A Request $i: "
+  curl -s -o /dev/null -w "%{http_code}" "http://localhost:8085/api/test/composite?userId=user-A"
+  echo ""
+done
+
+# User B - also gets 10 requests (separate bucket!)
+for i in {1..12}; do
+  echo -n "User B Request $i: "
+  curl -s -o /dev/null -w "%{http_code}" "http://localhost:8085/api/test/composite?userId=user-B"
+  echo ""
+done
+```
+
+Expected: User A gets 429 after 10 requests, but User B still has 10 requests available because they have separate buckets (different composite keys: `127.0.0.1:user-A` vs `127.0.0.1:user-B`).
+
+### Step 5: Check Configuration
+
+```bash
+curl http://localhost:8085/api/test/info | jq
 ```
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                 Standalone Application (8085)                   │
+│                 Servlet Filter Chain                            │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │              @EnableFluxgateFilter                       │   │
-│  │  ┌───────────────────────────────────────────────────┐  │   │
-│  │  │         FluxgateRateLimitFilter                   │  │   │
-│  │  │                    │                               │  │   │
-│  │  │         StandaloneRateLimitHandler                │  │   │
-│  │  └───────────────────────────────────────────────────┘  │   │
-│  └─────────────────────────────────────────────────────────┘   │
+│  Order=1  compositeKeyApiFilter                                 │
+│           └─ /api/test/composite/** → "composite-key-rules"     │
+│              (CUSTOM scope: IP+User composite key)              │
 │                          │                                      │
-│            ┌─────────────┴─────────────┐                       │
-│            │                           │                        │
-│            ▼                           ▼                        │
-│  ┌──────────────────┐       ┌──────────────────┐               │
-│  │     MongoDB      │       │      Redis       │               │
-│  │  (Rule Storage)  │       │ (Token Bucket)   │               │
-│  │                  │       │                  │               │
-│  │  rate_limit_rules│       │  Lua Scripts     │               │
-│  └──────────────────┘       └──────────────────┘               │
+│  Order=2  multiFilterApiFilter                                  │
+│           └─ /api/test/multi-filter/** → "multi-filter-rules"   │
+│              (PER_IP: 2 rules)                                  │
+│                          │                                      │
+│  Order=3  apiFilter      ▼                                      │
+│           └─ /api/test/** → "standalone-rules"                  │
+│              (PER_IP: 1 rule)                                   │
+│              ⚠️  excludes: /api/test/composite/**               │
+│              ⚠️  excludes: /api/test/multi-filter/**            │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
+```
+
+### Important: Excluding Overlapping URL Patterns
+
+When using multiple filters with overlapping URL patterns, you **MUST** exclude the more specific pattern from the broader filter to prevent double rate limiting.
+
+```java
+// apiFilter covers /api/test/** but MUST exclude /api/test/multi-filter/**
+new String[] {"/api/test/**"},              // includePatterns
+new String[] {"/api/test/multi-filter/**"}, // excludePatterns - REQUIRED!
+```
+
+**Without exclusion**, a request to `/api/test/multi-filter` would be rate-limited by BOTH filters:
+
+1. `multiFilterApiFilter` (order=1) → applies `multi-filter-rules` (2 rules)
+2. `apiFilter` (order=2) → applies `standalone-rules` (1 rule) - **UNINTENDED!**
+
+This would result in **3 rules** being applied instead of the intended **2 rules**.
+
+## Rule Configuration
+
+| Rule Set | Rule ID | LimitScope | Limit | Endpoint |
+|----------|---------|------------|-------|----------|
+| standalone-rules | standalone-10-per-minute | PER_IP | 10 req/min | /api/test |
+| multi-filter-rules | multi-filter-10-per-minute | PER_IP | 10 req/min | /api/test/multi-filter |
+| multi-filter-rules | multi-filter-20-per-minute | PER_IP | 20 req/min | /api/test/multi-filter |
+| composite-key-rules | composite-10-per-minute | CUSTOM (ipUser) | 10 req/min | /api/test/composite |
+
+## LimitScope-based Key Resolution
+
+The `LimitScopeKeyResolver` resolves rate limit keys based on the rule's `LimitScope`:
+
+| LimitScope | Key Source | Description |
+|------------|------------|-------------|
+| `GLOBAL` | `"global"` | Single bucket for all requests |
+| `PER_IP` | `RequestContext.clientIp` | One bucket per IP address |
+| `PER_USER` | `RequestContext.userId` | One bucket per user (from X-User-Id header) |
+| `PER_API_KEY` | `RequestContext.apiKey` | One bucket per API key (from X-API-Key header) |
+| `CUSTOM` | `attributes.get(keyStrategyId)` | Custom key from RequestContext attributes |
+
+## Composite Key (IP + User)
+
+The composite key endpoint demonstrates rate limiting by IP and User combination using `LimitScope.CUSTOM`:
+
+```java
+// Rule configuration
+RateLimitRule rule = RateLimitRule.builder("composite-10-per-minute")
+    .scope(LimitScope.CUSTOM)
+    .keyStrategyId("ipUser")  // Looks up context.attributes.get("ipUser")
+    .addBand(RateLimitBand.builder(Duration.ofMinutes(1), 10).build())
+    .build();
+```
+
+The `RequestContextCustomizer` builds the composite key:
+
+```java
+// Build composite key: "192.168.1.100:user-123"
+String clientIp = builder.build().getClientIp();
+if (userId != null && !userId.isEmpty()) {
+    builder.attribute("ipUser", clientIp + ":" + userId);
+} else {
+    builder.attribute("ipUser", clientIp);  // Fallback to IP only
+}
+```
+
+### Redis Key Examples (Composite)
+
+| User ID | Composite Key | Redis Key |
+|---------|---------------|-----------|
+| (none) | `127.0.0.1` | `fluxgate:composite-key-rules:composite-10-per-minute:127.0.0.1:per-minute` |
+| `user-A` | `127.0.0.1:user-A` | `fluxgate:composite-key-rules:composite-10-per-minute:127.0.0.1:user-A:per-minute` |
+| `user-B` | `127.0.0.1:user-B` | `fluxgate:composite-key-rules:composite-10-per-minute:127.0.0.1:user-B:per-minute` |
+
+## Rate Limiting by User ID or API Key
+
+This sample demonstrates rate limiting by different keys using **LimitScope**:
+
+### Testing Different LimitScopes
+
+```bash
+# 1. PER_IP (default for standalone-rules)
+curl http://localhost:8085/api/test
+
+# 2. PER_USER - requires rule with scope=PER_USER
+#    The X-User-Id header sets RequestContext.userId
+curl -H "X-User-Id: user-123" http://localhost:8085/api/test
+
+# 3. PER_API_KEY - requires rule with scope=PER_API_KEY
+#    The X-API-Key header sets RequestContext.apiKey
+curl -H "X-API-Key: api-key-abc" http://localhost:8085/api/test
+
+# 4. CUSTOM (composite key) - IP+User combination
+curl "http://localhost:8085/api/test/composite?userId=user-123"
+```
+
+### Redis Key Format
+
+The Redis key format is: `fluxgate:{ruleSetId}:{ruleId}:{keyValue}:{bandLabel}`
+
+The `{keyValue}` is determined by the rule's `LimitScope`:
+
+| LimitScope | Header/Param | Key Value | Redis Key Example |
+|------------|--------------|-----------|-------------------|
+| PER_IP | (none) | `127.0.0.1` | `fluxgate:standalone-rules:...:127.0.0.1:per-minute` |
+| PER_USER | X-User-Id | `user-123` | `fluxgate:...:user-123:per-minute` |
+| PER_API_KEY | X-API-Key | `api-key-abc` | `fluxgate:...:api-key-abc:per-minute` |
+| CUSTOM | userId param | `127.0.0.1:user-123` | `fluxgate:...:127.0.0.1:user-123:per-minute` |
+
+### Test: Different Users with Composite Key
+
+```bash
+# User A - 10 requests allowed (key: 127.0.0.1:user-A)
+for i in {1..12}; do
+  echo -n "User A Request $i: "
+  curl -s -o /dev/null -w "%{http_code}" "http://localhost:8085/api/test/composite?userId=user-A"
+  echo ""
+done
+
+# User B - also has 10 requests (separate bucket, key: 127.0.0.1:user-B)
+for i in {1..12}; do
+  echo -n "User B Request $i: "
+  curl -s -o /dev/null -w "%{http_code}" "http://localhost:8085/api/test/composite?userId=user-B"
+  echo ""
+done
+```
+
+Expected: User A gets 429 after 10 requests, but User B still has 10 requests available.
+
+## RequestContext Customization
+
+Customize request context before rate limiting to set values used by `LimitScopeKeyResolver`:
+
+```java
+@Bean
+public RequestContextCustomizer requestContextCustomizer() {
+    return (builder, request) -> {
+        // Set userId for PER_USER scope
+        String userId = request.getHeader("X-User-Id");
+        if (userId != null && !userId.isEmpty()) {
+            builder.userId(userId);
+        }
+
+        // Set apiKey for PER_API_KEY scope
+        String apiKey = request.getHeader("X-API-Key");
+        if (apiKey != null && !apiKey.isEmpty()) {
+            builder.apiKey(apiKey);
+        }
+
+        // Override client IP from proxy header (for PER_IP scope)
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null) {
+            builder.clientIp(realIp);
+        }
+
+        // Build composite key for CUSTOM scope with keyStrategyId="ipUser"
+        String clientIp = builder.build().getClientIp();
+        if (userId != null && !userId.isEmpty()) {
+            builder.attribute("ipUser", clientIp + ":" + userId);
+        } else {
+            builder.attribute("ipUser", clientIp);
+        }
+
+        return builder;
+    };
+}
+```
+
+### Default LimitScopeKeyResolver
+
+The default `LimitScopeKeyResolver` resolves keys based on the rule's `LimitScope`:
+
+```java
+// The default KeyResolver is automatically configured:
+@Bean
+public KeyResolver keyResolver() {
+    return new LimitScopeKeyResolver();
+}
+
+// LimitScopeKeyResolver logic:
+// - GLOBAL → "global"
+// - PER_IP → context.getClientIp()
+// - PER_USER → context.getUserId() (fallback to clientIp)
+// - PER_API_KEY → context.getApiKey() (fallback to clientIp)
+// - CUSTOM → context.getAttributes().get(rule.getKeyStrategyId())
 ```
 
 ## Configuration
@@ -132,6 +372,8 @@ fluxgate:
   mongodb:
     uri: mongodb://fluxgate:fluxgate123@localhost:27017/fluxgate?authSource=admin
     database: fluxgate
+    event-collection: rate_limit_events
+    ddl-auto: create
   redis:
     uri: redis://localhost:6379
 ```
@@ -249,24 +491,12 @@ Key metrics:
 
 ## Swagger UI
 
-Access the API documentation at:
 ```
 http://localhost:8085/swagger-ui.html
 ```
-
-## Differences from Other Samples
-
-| Feature | Standalone | Filter | Redis | Mongo |
-|---------|:----------:|:------:|:-----:|:-----:|
-| Direct MongoDB | ✅ | ❌ | ❌ | ✅ |
-| Direct Redis | ✅ | ❌ | ✅ | ❌ |
-| HTTP Filter | ✅ | ✅ | ✅ | ❌ |
-| Rule Management API | ✅ | ❌ | ❌ | ✅ |
-| Self-contained | ✅ | ❌ | ❌ | ❌ |
 
 ## Learn More
 
 - [FluxGate Samples Overview](../README.md)
 - [FluxGate Core](../../fluxgate-core/README.md)
 - [Redis Rate Limiter](../../fluxgate-redis-ratelimiter/README.md)
-- [MongoDB Adapter](../../fluxgate-mongo-adapter/README.md)

--- a/fluxgate-samples/fluxgate-sample-standalone/pom.xml
+++ b/fluxgate-samples/fluxgate-sample-standalone/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate-samples</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-sample-standalone</artifactId>

--- a/fluxgate-samples/fluxgate-sample-standalone/src/main/java/org/fluxgate/sample/standalone/StandaloneApplication.java
+++ b/fluxgate-samples/fluxgate-sample-standalone/src/main/java/org/fluxgate/sample/standalone/StandaloneApplication.java
@@ -1,26 +1,39 @@
 package org.fluxgate.sample.standalone;
 
-import org.fluxgate.sample.standalone.handler.StandaloneRateLimitHandler;
-import org.fluxgate.spring.annotation.EnableFluxgateFilter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
  * Standalone FluxGate sample application.
  *
- * <p>This application demonstrates: - Direct MongoDB connection for rule storage - Direct Redis
- * connection for rate limiting - @EnableFluxgateFilter for HTTP filter integration
+ * <p>This application demonstrates:
  *
- * <p>APIs: - POST /api/admin/ruleset - Create a rate limit ruleset (saved to MongoDB) - POST
- * /api/admin/sync - Sync rules to Redis rate limiter - GET /api/test - Rate-limited test endpoint
- * (10 requests/minute)
+ * <ul>
+ *   <li>Direct MongoDB connection for rule storage
+ *   <li>Direct Redis connection for rate limiting
+ *   <li>Multiple rate limit filters with different priorities (Java Config)
+ *   <li>RequestContext customization for IP override and attribute injection
+ *   <li>WAIT_FOR_REFILL policy for public APIs
+ * </ul>
+ *
+ * <p>Filter Configuration (see {@code MultipleFiltersConfig}):
+ *
+ * <ul>
+ *   <li>Filter 1 (order=1): /api/public/** - Public API with WAIT_FOR_REFILL
+ *   <li>Filter 2 (order=2): /api/** - Standard API with REJECT_REQUEST
+ *   <li>Filter 3 (order=3): /api/admin/** - Admin API with strict limits
+ * </ul>
+ *
+ * <p>APIs:
+ *
+ * <ul>
+ *   <li>POST /api/admin/ruleset - Create rate limit rules (saved to MongoDB)
+ *   <li>POST /api/admin/sync - Sync rules to Redis rate limiter
+ *   <li>GET /api/test - Rate-limited test endpoint (10 requests/minute)
+ *   <li>GET /api/public/test - Public API with WAIT_FOR_REFILL policy
+ * </ul>
  */
 @SpringBootApplication
-@EnableFluxgateFilter(
-    handler = StandaloneRateLimitHandler.class,
-    ruleSetId = "standalone-rules",
-    includePatterns = {"/api/**"},
-    excludePatterns = {"/api/admin/**", "/swagger-ui/**", "/v3/api-docs/**"})
 public class StandaloneApplication {
 
   public static void main(String[] args) {

--- a/fluxgate-samples/fluxgate-sample-standalone/src/main/java/org/fluxgate/sample/standalone/config/MultipleFiltersConfig.java
+++ b/fluxgate-samples/fluxgate-sample-standalone/src/main/java/org/fluxgate/sample/standalone/config/MultipleFiltersConfig.java
@@ -1,0 +1,249 @@
+package org.fluxgate.sample.standalone.config;
+
+import org.fluxgate.core.handler.FluxgateRateLimitHandler;
+import org.fluxgate.spring.filter.FluxgateRateLimitFilter;
+import org.fluxgate.spring.filter.RequestContextCustomizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for multiple rate limit filters with different priorities.
+ *
+ * <p>This demonstrates how to configure multiple {@link FluxgateRateLimitFilter} instances with:
+ *
+ * <ul>
+ *   <li>Different rule sets for different URL patterns
+ *   <li>Different priorities (order) - lower number = higher priority
+ *   <li>RequestContext customization
+ * </ul>
+ *
+ * <p>Filter execution order (in Servlet Filter Chain):
+ *
+ * <pre>
+ * 1. compositeKeyApiFilter (order=1)  - /api/test/composite/**    - Uses "composite-key-rules" (IP+User key)
+ * 2. multiFilterApiFilter (order=2)   - /api/test/multi-filter/** - Uses "multi-filter-rules" (2 rules)
+ * 3. apiFilter (order=3)              - /api/test/**              - Uses "standalone-rules" (1 rule)
+ * </pre>
+ *
+ * <p>Test endpoints:
+ *
+ * <ul>
+ *   <li>GET /api/test - Standard rate limit test (10 req/min per IP)
+ *   <li>GET /api/test/multi-filter - Multi-filter test (10 req/min + 20 req/min)
+ *   <li>GET /api/test/composite - Composite key test (10 req/min per IP+User)
+ * </ul>
+ */
+@Configuration
+public class MultipleFiltersConfig {
+
+  private static final Logger log = LoggerFactory.getLogger(MultipleFiltersConfig.class);
+
+  /**
+   * RequestContext customizer that extracts rate limit key values from headers.
+   *
+   * <p>This customizer sets the following values for use by {@link
+   * org.fluxgate.core.key.LimitScopeKeyResolver}:
+   *
+   * <ul>
+   *   <li><b>X-User-Id</b> → builder.userId() (for PER_USER scope)
+   *   <li><b>X-API-Key</b> → builder.apiKey() (for PER_API_KEY scope)
+   *   <li><b>X-Real-IP</b> → builder.clientIp() (overrides IP for proxy setups)
+   *   <li><b>X-Tenant-Id</b> → builder.attribute("tenantId", ...) (for CUSTOM scope)
+   *   <li><b>X-Request-Id</b> → builder.attribute("requestId", ...) (for tracing)
+   * </ul>
+   *
+   * <p><b>Example usage:</b>
+   *
+   * <pre>
+   * # Rate limit by user ID (requires rule with LimitScope.PER_USER)
+   * curl -H "X-User-Id: user-123" http://localhost:8085/api/test
+   *
+   * # Rate limit by API key (requires rule with LimitScope.PER_API_KEY)
+   * curl -H "X-API-Key: api-key-abc" http://localhost:8085/api/test
+   *
+   * # Rate limit by IP (requires rule with LimitScope.PER_IP - default)
+   * curl http://localhost:8085/api/test
+   * </pre>
+   *
+   * <p><b>Note:</b> The rate limit key is determined by the rule's LimitScope, not by which headers
+   * are present. If a rule has LimitScope.PER_USER but X-User-Id header is missing, it will fall
+   * back to clientIp.
+   */
+  @Bean
+  public RequestContextCustomizer requestContextCustomizer() {
+    return (builder, request) -> {
+      // Set userId for PER_USER scope rules
+      String userId = request.getHeader("X-User-Id");
+      if (userId != null && !userId.isEmpty()) {
+        log.debug("Setting userId from X-User-Id header: {}", userId);
+        builder.userId(userId);
+      }
+
+      // Set apiKey for PER_API_KEY scope rules
+      String apiKey = request.getHeader("X-API-Key");
+      if (apiKey != null && !apiKey.isEmpty()) {
+        log.debug("Setting apiKey from X-API-Key header: {}", apiKey);
+        builder.apiKey(apiKey);
+      }
+
+      // Override client IP from X-Real-IP header (common for nginx proxy)
+      String realIp = request.getHeader("X-Real-IP");
+      if (realIp != null && !realIp.isEmpty()) {
+        log.debug("Overriding client IP from X-Real-IP: {}", realIp);
+        builder.clientIp(realIp);
+      }
+
+      // Add tenant ID for CUSTOM scope with keyStrategyId="tenantId"
+      String tenantId = request.getHeader("X-Tenant-Id");
+      if (tenantId != null) {
+        builder.attribute("tenantId", tenantId);
+      }
+
+      // Add request ID for tracing (not used for rate limiting)
+      String requestId = request.getHeader("X-Request-Id");
+      if (requestId != null) {
+        builder.attribute("requestId", requestId);
+      }
+
+      // Build composite key (IP:userId) for CUSTOM scope with keyStrategyId="ipUser"
+      // This demonstrates how to combine multiple identifiers into a single rate limit key
+      String clientIp = builder.build().getClientIp();
+      if (userId != null && !userId.isEmpty()) {
+        // Composite key: "192.168.1.100:user-123"
+        builder.attribute("ipUser", clientIp + ":" + userId);
+        log.debug("Built composite ipUser key: {}:{}", clientIp, userId);
+      } else {
+        // Fallback to IP only if no userId provided
+        builder.attribute("ipUser", clientIp);
+        log.debug("Built ipUser key (IP only): {}", clientIp);
+      }
+
+      return builder;
+    };
+  }
+
+  /**
+   * Filter 1: Composite key API rate limiter (highest priority).
+   *
+   * <p>Configuration:
+   *
+   * <ul>
+   *   <li>Order: 1 (highest priority - checked first)
+   *   <li>RuleSet: "composite-key-rules" (1 rule with CUSTOM scope, keyStrategyId="ipUser")
+   *   <li>URL Pattern: /api/test/composite/**
+   *   <li>Key Strategy: IP+User composite key (e.g., "192.168.1.100:user-123")
+   * </ul>
+   *
+   * <p>Usage:
+   *
+   * <pre>
+   * # Different users from same IP have separate rate limits
+   * curl -H "X-User-Id: user-A" http://localhost:8085/api/test/composite
+   * curl -H "X-User-Id: user-B" http://localhost:8085/api/test/composite
+   * </pre>
+   */
+  @Bean
+  public FilterRegistrationBean<FluxgateRateLimitFilter> compositeKeyApiFilter(
+      FluxgateRateLimitHandler handler, RequestContextCustomizer customizer) {
+    log.info("Registering compositeKeyApiFilter with order=1 for /api/test/composite/**");
+
+    FluxgateRateLimitFilter filter =
+        new FluxgateRateLimitFilter(
+            handler,
+            "composite-key-rules", // ruleSetId with CUSTOM scope
+            new String[] {"/api/test/composite/**"}, // includePatterns
+            new String[] {}, // excludePatterns
+            false, // waitForRefillEnabled
+            5000, // maxWaitTimeMs
+            100, // maxConcurrentWaits
+            customizer);
+
+    FilterRegistrationBean<FluxgateRateLimitFilter> registration =
+        new FilterRegistrationBean<>(filter);
+    registration.setOrder(1); // Highest priority - checked first
+    registration.setName("compositeKeyApiRateLimitFilter");
+    registration.addUrlPatterns("/api/test/composite/*");
+    return registration;
+  }
+
+  /**
+   * Filter 2: Multi-filter API rate limiter.
+   *
+   * <p>Configuration:
+   *
+   * <ul>
+   *   <li>Order: 2
+   *   <li>RuleSet: "multi-filter-rules" (2 rules: 10 req/min + 20 req/min)
+   *   <li>URL Pattern: /api/test/multi-filter/**
+   *   <li>Policy: REJECT_REQUEST
+   * </ul>
+   */
+  @Bean
+  public FilterRegistrationBean<FluxgateRateLimitFilter> multiFilterApiFilter(
+      FluxgateRateLimitHandler handler, RequestContextCustomizer customizer) {
+    log.info("Registering multiFilterApiFilter with order=2 for /api/test/multi-filter/**");
+
+    FluxgateRateLimitFilter filter =
+        new FluxgateRateLimitFilter(
+            handler,
+            "multi-filter-rules", // ruleSetId - different from standalone-rules
+            new String[] {"/api/test/multi-filter/**"}, // includePatterns
+            new String[] {}, // excludePatterns
+            false, // waitForRefillEnabled
+            5000, // maxWaitTimeMs
+            100, // maxConcurrentWaits
+            customizer);
+
+    FilterRegistrationBean<FluxgateRateLimitFilter> registration =
+        new FilterRegistrationBean<>(filter);
+    registration.setOrder(2); // Second priority
+    registration.setName("multiFilterApiRateLimitFilter");
+    registration.addUrlPatterns("/api/test/multi-filter/*");
+    return registration;
+  }
+
+  /**
+   * Filter 3: Standard API rate limiter.
+   *
+   * <p>Configuration:
+   *
+   * <ul>
+   *   <li>Order: 3 (lowest priority)
+   *   <li>RuleSet: "standalone-rules" (1 rule: 10 req/min)
+   *   <li>URL Pattern: /api/test/** (excluding composite and multi-filter)
+   *   <li>Policy: REJECT_REQUEST (immediate 429 response)
+   * </ul>
+   *
+   * <p><b>NOTICE:</b> The excludePatterns MUST include other specific endpoints to prevent double
+   * rate limiting. Without these exclusions, requests would be checked by BOTH filters.
+   */
+  @Bean
+  public FilterRegistrationBean<FluxgateRateLimitFilter> apiFilter(
+      FluxgateRateLimitHandler handler, RequestContextCustomizer customizer) {
+    log.info(
+        "Registering apiFilter with order=3 for /api/test/** (excluding composite, multi-filter)");
+
+    FluxgateRateLimitFilter filter =
+        new FluxgateRateLimitFilter(
+            handler,
+            "standalone-rules", // ruleSetId
+            new String[] {"/api/test/**"}, // includePatterns
+            new String[] {
+              "/api/test/composite/**", "/api/test/multi-filter/**"
+            }, // excludePatterns - Exclude specific endpoints
+            false, // waitForRefillEnabled
+            5000, // maxWaitTimeMs
+            100, // maxConcurrentWaits
+            customizer);
+
+    FilterRegistrationBean<FluxgateRateLimitFilter> registration =
+        new FilterRegistrationBean<>(filter);
+    registration.setOrder(3); // Lowest priority
+    registration.setName("apiRateLimitFilter");
+    registration.addUrlPatterns("/api/test/*");
+    return registration;
+  }
+}

--- a/fluxgate-samples/fluxgate-sample-standalone/src/main/java/org/fluxgate/sample/standalone/controller/AdminController.java
+++ b/fluxgate-samples/fluxgate-sample-standalone/src/main/java/org/fluxgate/sample/standalone/controller/AdminController.java
@@ -22,9 +22,15 @@ import org.springframework.web.bind.annotation.*;
 /**
  * Admin API for managing rate limit rules.
  *
- * <p>Endpoints: - POST /api/admin/ruleset - Create/update the default ruleset (10 requests/minute)
- * - POST /api/admin/sync - Sync rules (just confirms setup is ready) - GET /api/admin/ruleset - Get
- * current ruleset
+ * <p>This controller provides APIs to create different rule sets:
+ *
+ * <ul>
+ *   <li>POST /api/admin/rules/standalone - Create rule for /api/test (10 req/min)
+ *   <li>POST /api/admin/rules/multi-filter - Create 2 rules for /api/test/multi-filter (5 req/sec +
+ *       20 req/min)
+ *   <li>POST /api/admin/rules/all - Create all rules at once
+ *   <li>GET /api/admin/rules/{ruleSetId} - Get rules for a specific rule set
+ * </ul>
  */
 @RestController
 @RequestMapping("/api/admin")
@@ -32,7 +38,11 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
   private static final Logger log = LoggerFactory.getLogger(AdminController.class);
-  private static final String DEFAULT_RULESET_ID = "standalone-rules";
+
+  // Rule Set IDs
+  private static final String STANDALONE_RULESET_ID = "standalone-rules";
+  private static final String MULTI_FILTER_RULESET_ID = "multi-filter-rules";
+  private static final String COMPOSITE_KEY_RULESET_ID = "composite-key-rules";
 
   private final RateLimitRuleSetProvider ruleSetProvider;
   private final RateLimitRuleRepository ruleRepository;
@@ -43,65 +53,192 @@ public class AdminController {
     this.ruleRepository = ruleRepository;
   }
 
-  @PostMapping("/ruleset")
+  /**
+   * Create rule for /api/test endpoint.
+   *
+   * <p>Creates 1 rule: 10 requests per minute per IP
+   */
+  @PostMapping("/rules/standalone")
   @Operation(
-      summary = "Create default ruleset",
-      description = "Creates a rate limit ruleset with 10 requests per minute limit")
-  public ResponseEntity<Map<String, Object>> createRuleSet() {
-    log.info("Creating default ruleset: {}", DEFAULT_RULESET_ID);
+      summary = "Create standalone rule",
+      description =
+          "Creates a rate limit rule for /api/test endpoint. "
+              + "Limit: 10 requests per minute per IP. "
+              + "RuleSet: standalone-rules")
+  public ResponseEntity<Map<String, Object>> createStandaloneRule() {
+    log.info("Creating standalone rule for /api/test");
 
-    // Create a rule: 10 requests per minute per IP
-    // Using custom attributes to store metadata (e.g., tier, team, external references)
     RateLimitRule rule =
-        RateLimitRule.builder("rate-limit-rule-1")
-            .name("Standard Rate Limit")
+        RateLimitRule.builder("standalone-10-per-minute")
+            .name("Standalone API - 10 req/min")
             .enabled(true)
             .scope(LimitScope.PER_IP)
             .keyStrategyId("ip")
             .onLimitExceedPolicy(OnLimitExceedPolicy.REJECT_REQUEST)
             .addBand(RateLimitBand.builder(Duration.ofMinutes(1), 10).label("per-minute").build())
-            .ruleSetId(DEFAULT_RULESET_ID)
-            // Custom attributes for user-defined metadata
-            // These are stored in MongoDB and can be queried:
-            // db.rate_limit_rules.find({"attributes.tier": "standard"})
-            .attribute("tier", "standard")
-            .attribute("team", "platform")
-            .attribute("description", "Default rate limit for API endpoints")
+            .ruleSetId(STANDALONE_RULESET_ID)
+            .attribute("endpoint", "/api/test")
+            .attribute("description", "Standard rate limit for test API")
             .build();
 
-    // Save rule to MongoDB via repository
     ruleRepository.save(rule);
-    log.info("Rule saved to MongoDB: {}", rule.getId());
+    log.info("Standalone rule saved: {}", rule.getId());
 
     Map<String, Object> response = new HashMap<>();
     response.put("success", true);
-    response.put("ruleSetId", DEFAULT_RULESET_ID);
+    response.put("ruleSetId", STANDALONE_RULESET_ID);
     response.put("ruleId", rule.getId());
+    response.put("endpoint", "/api/test");
     response.put("limit", "10 requests per minute per IP");
-    response.put("attributes", rule.getAttributes());
     response.put("createdAt", Instant.now().toString());
 
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping("/ruleset")
+  /**
+   * Create rules for /api/test/multi-filter endpoint.
+   *
+   * <p>Creates 2 rules:
+   *
+   * <ul>
+   *   <li>Rule 1: 10 requests per minute
+   *   <li>Rule 2: 20 requests per minute
+   * </ul>
+   *
+   * <p>Both rules apply - request is rejected if ANY rule is exceeded.
+   */
+  @PostMapping("/rules/multi-filter")
   @Operation(
-      summary = "Get current ruleset",
-      description = "Retrieves the current rate limit ruleset from MongoDB")
-  public ResponseEntity<Map<String, Object>> getRuleSet() {
-    Optional<RateLimitRuleSet> ruleSetOpt = ruleSetProvider.findById(DEFAULT_RULESET_ID);
+      summary = "Create multi-filter rules",
+      description =
+          "Creates 2 rate limit rules for /api/test/multi-filter endpoint. "
+              + "Rule 1: 10 requests per minute. "
+              + "Rule 2: 20 requests per minute. "
+              + "RuleSet: multi-filter-rules")
+  public ResponseEntity<Map<String, Object>> createMultiFilterRules() {
+    log.info("Creating multi-filter rules for /api/test/multi-filter");
+
+    // Rule 1: 10 requests per minute
+    RateLimitRule rule1 =
+        RateLimitRule.builder("multi-filter-10-per-minute")
+            .name("Multi-Filter API - Rule 1 (10 req/min)")
+            .enabled(true)
+            .scope(LimitScope.PER_IP)
+            .keyStrategyId("ip")
+            .onLimitExceedPolicy(OnLimitExceedPolicy.REJECT_REQUEST)
+            .addBand(
+                RateLimitBand.builder(Duration.ofMinutes(1), 10).label("rule1-per-minute").build())
+            .ruleSetId(MULTI_FILTER_RULESET_ID)
+            .attribute("endpoint", "/api/test/multi-filter")
+            .attribute("ruleNumber", "1")
+            .attribute("description", "First rate limit rule - 10 requests per minute")
+            .build();
+
+    // Rule 2: 20 requests per minute
+    RateLimitRule rule2 =
+        RateLimitRule.builder("multi-filter-20-per-minute")
+            .name("Multi-Filter API - Rule 2 (20 req/min)")
+            .enabled(true)
+            .scope(LimitScope.PER_IP)
+            .keyStrategyId("ip")
+            .onLimitExceedPolicy(OnLimitExceedPolicy.REJECT_REQUEST)
+            .addBand(
+                RateLimitBand.builder(Duration.ofMinutes(1), 20).label("rule2-per-minute").build())
+            .ruleSetId(MULTI_FILTER_RULESET_ID)
+            .attribute("endpoint", "/api/test/multi-filter")
+            .attribute("ruleNumber", "2")
+            .attribute("description", "Second rate limit rule - 20 requests per minute")
+            .build();
+
+    ruleRepository.save(rule1);
+    ruleRepository.save(rule2);
+    log.info("Multi-filter rules saved: {}, {}", rule1.getId(), rule2.getId());
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("success", true);
+    response.put("ruleSetId", MULTI_FILTER_RULESET_ID);
+    response.put("endpoint", "/api/test/multi-filter");
+    response.put(
+        "rules",
+        Map.of(
+            "rule1",
+            Map.of("ruleId", rule1.getId(), "limit", "10 requests per minute"),
+            "rule2",
+            Map.of("ruleId", rule2.getId(), "limit", "20 requests per minute")));
+    response.put("note", "Both rules apply - request rejected if ANY rule exceeded");
+    response.put("createdAt", Instant.now().toString());
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * Create rule for /api/test/composite endpoint.
+   *
+   * <p>Creates a rule with CUSTOM scope and keyStrategyId="ipUser". The RequestContextCustomizer
+   * builds the composite key by combining IP and User ID: "192.168.1.100:user-123"
+   *
+   * <p>If X-User-Id header is not provided, falls back to IP only.
+   */
+  @PostMapping("/rules/composite")
+  @Operation(
+      summary = "Create composite key rule",
+      description =
+          "Creates a rate limit rule for /api/test/composite endpoint with composite key (IP+User). "
+              + "Limit: 10 requests per minute per IP+User combination. "
+              + "RuleSet: composite-key-rules. "
+              + "Use X-User-Id header to provide user identifier.")
+  public ResponseEntity<Map<String, Object>> createCompositeKeyRule() {
+    log.info("Creating composite key rule for /api/test/composite");
+
+    RateLimitRule rule =
+        RateLimitRule.builder("composite-10-per-minute")
+            .name("Composite Key API - 10 req/min per IP+User")
+            .enabled(true)
+            .scope(LimitScope.CUSTOM)
+            .keyStrategyId("ipUser") // Custom key strategy - resolved from RequestContext attribute
+            .onLimitExceedPolicy(OnLimitExceedPolicy.REJECT_REQUEST)
+            .addBand(RateLimitBand.builder(Duration.ofMinutes(1), 10).label("per-minute").build())
+            .ruleSetId(COMPOSITE_KEY_RULESET_ID)
+            .attribute("endpoint", "/api/test/composite")
+            .attribute("description", "Rate limit by IP+User composite key")
+            .build();
+
+    ruleRepository.save(rule);
+    log.info("Composite key rule saved: {}", rule.getId());
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("success", true);
+    response.put("ruleSetId", COMPOSITE_KEY_RULESET_ID);
+    response.put("ruleId", rule.getId());
+    response.put("endpoint", "/api/test/composite");
+    response.put("limit", "10 requests per minute per IP+User");
+    response.put("keyStrategy", "ipUser (composite of IP and User ID)");
+    response.put("usage", "curl -H 'X-User-Id: user-123' http://localhost:8085/api/test/composite");
+    response.put("createdAt", Instant.now().toString());
+
+    return ResponseEntity.ok(response);
+  }
+
+  /** Get rules for a specific rule set. */
+  @GetMapping("/rules/{ruleSetId}")
+  @Operation(
+      summary = "Get rules by rule set ID",
+      description = "Retrieves all rules for a specific rule set from MongoDB")
+  public ResponseEntity<Map<String, Object>> getRuleSet(@PathVariable String ruleSetId) {
+    Optional<RateLimitRuleSet> ruleSetOpt = ruleSetProvider.findById(ruleSetId);
 
     Map<String, Object> response = new HashMap<>();
     if (ruleSetOpt.isEmpty()) {
       response.put("exists", false);
-      response.put("message", "RuleSet not found. Call POST /api/admin/ruleset to create it.");
+      response.put("ruleSetId", ruleSetId);
+      response.put(
+          "message", "RuleSet not found. Create rules first using POST /api/admin/rules/*");
       return ResponseEntity.ok(response);
     }
 
     RateLimitRuleSet ruleSet = ruleSetOpt.get();
     response.put("exists", true);
-    response.put("id", ruleSet.getId());
-    response.put("description", ruleSet.getDescription());
+    response.put("ruleSetId", ruleSet.getId());
     response.put("rulesCount", ruleSet.getRules().size());
     response.put(
         "rules",
@@ -123,7 +260,6 @@ public class AdminController {
                                       "capacity", band.getCapacity(),
                                       "windowSeconds", band.getWindow().toSeconds()))
                           .toList());
-                  // Include custom attributes if present
                   if (!rule.getAttributes().isEmpty()) {
                     ruleMap.put("attributes", rule.getAttributes());
                   }
@@ -131,43 +267,6 @@ public class AdminController {
                 })
             .toList());
 
-    return ResponseEntity.ok(response);
-  }
-
-  @PostMapping("/sync")
-  @Operation(
-      summary = "Sync rules to Redis",
-      description = "Confirms that rules are synced and ready for rate limiting")
-  public ResponseEntity<Map<String, Object>> syncRules() {
-    log.info("Syncing rules to Redis...");
-
-    Optional<RateLimitRuleSet> ruleSetOpt = ruleSetProvider.findById(DEFAULT_RULESET_ID);
-
-    Map<String, Object> response = new HashMap<>();
-    if (ruleSetOpt.isEmpty()) {
-      response.put("success", false);
-      response.put("message", "RuleSet not found. Call POST /api/admin/ruleset first.");
-      return ResponseEntity.badRequest().body(response);
-    }
-
-    RateLimitRuleSet ruleSet = ruleSetOpt.get();
-
-    // In a real application, you might want to:
-    // 1. Pre-load rules into a cache
-    // 2. Initialize Redis token buckets
-    // 3. Warm up connections
-
-    response.put("success", true);
-    response.put("ruleSetId", ruleSet.getId());
-    response.put("rulesCount", ruleSet.getRules().size());
-    response.put("status", "synced");
-    response.put(
-        "message",
-        "Rules are ready for rate limiting. "
-            + "Rate limiter will use Redis for token bucket operations.");
-    response.put("syncedAt", Instant.now().toString());
-
-    log.info("Rules synced successfully: {} rules", ruleSet.getRules().size());
     return ResponseEntity.ok(response);
   }
 }

--- a/fluxgate-samples/fluxgate-sample-standalone/src/main/java/org/fluxgate/sample/standalone/controller/TestController.java
+++ b/fluxgate-samples/fluxgate-sample-standalone/src/main/java/org/fluxgate/sample/standalone/controller/TestController.java
@@ -14,13 +14,19 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Test API that is rate-limited by @EnableFluxgateFilter.
+ * Test API demonstrating multiple rate limit filters.
  *
- * <p>This endpoint is limited to 10 requests per minute per IP address. The rate limit is enforced
- * by the FluxgateRateLimitFilter.
+ * <p>Endpoints:
+ *
+ * <ul>
+ *   <li>/api/test - Uses "standalone-rules" (10 req/min per IP)
+ *   <li>/api/test/multi-filter - Uses "multi-filter-rules" (10 req/min + 20 req/min)
+ *   <li>/api/test/composite - Uses "composite-key-rules" (10 req/min per IP+User)
+ * </ul>
  */
 @RestController
 @RequestMapping("/api/test")
@@ -28,50 +34,170 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestController {
 
   private static final Logger log = LoggerFactory.getLogger(TestController.class);
-  private final AtomicLong requestCounter = new AtomicLong(0);
+  private final AtomicLong standaloneCounter = new AtomicLong(0);
+  private final AtomicLong multiFilterCounter = new AtomicLong(0);
+  private final AtomicLong compositeCounter = new AtomicLong(0);
 
+  /**
+   * Standard test endpoint.
+   *
+   * <p>Rate limit: 10 requests per minute per IP (standalone-rules)
+   */
   @GetMapping
   @Operation(
-      summary = "Rate-limited test endpoint",
+      summary = "Standard rate-limited endpoint",
       description =
-          "This endpoint is rate-limited to 10 requests per minute per IP. "
-              + "Make sure to call POST /api/admin/ruleset first to set up the rules.")
+          "Rate-limited to 10 requests per minute per IP. "
+              + "Uses 'standalone-rules' rule set. "
+              + "Call POST /api/admin/rules/standalone first to create rules.")
   @ApiResponses({
     @ApiResponse(responseCode = "200", description = "Request allowed"),
     @ApiResponse(responseCode = "429", description = "Rate limit exceeded")
   })
   public ResponseEntity<Map<String, Object>> test(HttpServletRequest request) {
-    long count = requestCounter.incrementAndGet();
+    long count = standaloneCounter.incrementAndGet();
     String clientIp = getClientIp(request);
 
-    log.info("Test API called - Request #{} from IP: {}", count, clientIp);
+    log.info("[standalone] Request #{} from IP: {}", count, clientIp);
 
     Map<String, Object> response = new HashMap<>();
     response.put("success", true);
-    response.put("message", "Request successful!");
+    response.put("endpoint", "/api/test");
+    response.put("ruleSetId", "standalone-rules");
+    response.put("limit", "10 req/min");
     response.put("requestNumber", count);
     response.put("clientIp", clientIp);
     response.put("timestamp", Instant.now().toString());
-    response.put("note", "This endpoint is rate-limited to 10 requests per minute per IP.");
 
     return ResponseEntity.ok(response);
   }
 
+  /**
+   * Multi-filter test endpoint.
+   *
+   * <p>Rate limits (both rules apply - rejected if ANY rule exceeded):
+   *
+   * <ul>
+   *   <li>Rule 1: 10 requests per minute
+   *   <li>Rule 2: 20 requests per minute
+   * </ul>
+   */
+  @GetMapping("/multi-filter")
+  @Operation(
+      summary = "Multi-rule rate-limited endpoint",
+      description =
+          "Rate-limited by 2 rules: 10 req/min (rule1) + 20 req/min (rule2). "
+              + "Both rules apply - rejected if ANY rule exceeded. "
+              + "Uses 'multi-filter-rules' rule set. "
+              + "Call POST /api/admin/rules/multi-filter first to create rules.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "Request allowed"),
+    @ApiResponse(responseCode = "429", description = "Rate limit exceeded")
+  })
+  public ResponseEntity<Map<String, Object>> multiFilterTest(HttpServletRequest request) {
+    long count = multiFilterCounter.incrementAndGet();
+    String clientIp = getClientIp(request);
+
+    log.info("[multi-filter] Request #{} from IP: {}", count, clientIp);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("success", true);
+    response.put("endpoint", "/api/test/multi-filter");
+    response.put("ruleSetId", "multi-filter-rules");
+    response.put("limits", Map.of("rule1", "10 req/min", "rule2", "20 req/min"));
+    response.put("note", "Both rules apply - rejected if ANY rule exceeded");
+    response.put("requestNumber", count);
+    response.put("clientIp", clientIp);
+    response.put("timestamp", Instant.now().toString());
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * Composite key test endpoint.
+   *
+   * <p>Rate limit: 10 requests per minute per IP+User combination.
+   *
+   * <p>The composite key is built by combining client IP and user ID: "192.168.1.100:user-123"
+   *
+   * <p>Usage examples:
+   *
+   * <ul>
+   *   <li>curl http://localhost:8085/api/test/composite (uses IP only)
+   *   <li>curl -H "X-User-Id: user-123" http://localhost:8085/api/test/composite (uses IP:user-123)
+   * </ul>
+   *
+   * <p>Different users from the same IP have separate rate limits.
+   */
+  @GetMapping("/composite")
+  @Operation(
+      summary = "Composite key rate-limited endpoint",
+      description =
+          "Rate-limited to 10 requests per minute per IP+User combination. "
+              + "Uses 'composite-key-rules' rule set with CUSTOM scope. "
+              + "Provide X-User-Id header to set user identifier. "
+              + "Call POST /api/admin/rules/composite first to create rules.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "Request allowed"),
+    @ApiResponse(responseCode = "429", description = "Rate limit exceeded")
+  })
+  public ResponseEntity<Map<String, Object>> compositeTest(
+      HttpServletRequest request, @RequestParam(value = "userId") String userId) {
+    long count = compositeCounter.incrementAndGet();
+    String clientIp = getClientIp(request);
+    String compositeKey = userId != null ? clientIp + ":" + userId : clientIp;
+
+    log.info("[composite] Request #{} from compositeKey: {}", count, compositeKey);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("success", true);
+    response.put("endpoint", "/api/test/composite");
+    response.put("ruleSetId", "composite-key-rules");
+    response.put("limit", "10 req/min per IP+User");
+    response.put("compositeKey", compositeKey);
+    response.put("clientIp", clientIp);
+    response.put("userId", userId != null ? userId : "(not provided)");
+    response.put("requestNumber", count);
+    response.put("timestamp", Instant.now().toString());
+
+    return ResponseEntity.ok(response);
+  }
+
+  /** Get rate limit configuration info. */
   @GetMapping("/info")
   @Operation(
       summary = "Get rate limit info",
-      description = "Returns information about the rate limiting configuration")
+      description = "Returns information about all rate limiting configurations")
   public ResponseEntity<Map<String, Object>> info() {
     Map<String, Object> response = new HashMap<>();
-    response.put("endpoint", "/api/test");
-    response.put(
-        "rateLimit",
+
+    Map<String, Object> endpoints = new HashMap<>();
+    endpoints.put(
+        "/api/test",
         Map.of(
-            "requests", 10,
-            "window", "1 minute",
-            "scope", "per IP address"));
-    response.put("totalRequestsReceived", requestCounter.get());
-    response.put("note", "Rate limit headers (X-RateLimit-*) are included in responses");
+            "ruleSetId", "standalone-rules",
+            "limit", "10 req/min per IP",
+            "requests", standaloneCounter.get()));
+    endpoints.put(
+        "/api/test/multi-filter",
+        Map.of(
+            "ruleSetId", "multi-filter-rules",
+            "limits", Map.of("rule1", "10 req/min", "rule2", "20 req/min"),
+            "requests", multiFilterCounter.get()));
+    endpoints.put(
+        "/api/test/composite",
+        Map.of(
+            "ruleSetId", "composite-key-rules",
+            "limit", "10 req/min per IP+User",
+            "keyStrategy", "ipUser (IP:userId composite)",
+            "requests", compositeCounter.get()));
+    response.put("endpoints", endpoints);
+
+    Map<String, String> setup = new HashMap<>();
+    setup.put("standalone", "POST /api/admin/rules/standalone");
+    setup.put("multiFilter", "POST /api/admin/rules/multi-filter");
+    setup.put("composite", "POST /api/admin/rules/composite");
+    response.put("setup", setup);
 
     return ResponseEntity.ok(response);
   }

--- a/fluxgate-samples/pom.xml
+++ b/fluxgate-samples/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-samples</artifactId>

--- a/fluxgate-spring-boot-starter/pom.xml
+++ b/fluxgate-spring-boot-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-spring-boot-starter</artifactId>
@@ -20,6 +20,9 @@
 
     <properties>
         <spring-boot.version>3.3.5</spring-boot.version>
+        <!-- Lower coverage thresholds for this module due to many excluded auto-config classes -->
+        <jacoco.line.coverage>0.75</jacoco.line.coverage>
+        <jacoco.branch.coverage>0.65</jacoco.branch.coverage>
     </properties>
 
     <dependencies>
@@ -172,6 +175,9 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <configuration>
                     <excludes>
+                        <!-- AutoConfiguration classes require Spring context for testing -->
+                        <exclude>org/fluxgate/spring/autoconfigure/*AutoConfiguration.class</exclude>
+                        <exclude>org/fluxgate/spring/actuator/*</exclude>
                         <!-- Exclude auto-configurations that require external MongoDB/Redis services -->
                         <!-- These are tested via integration tests in sample applications -->
                         <exclude>**/FluxgateMongoAutoConfiguration.class</exclude>
@@ -186,6 +192,8 @@
                         <exclude>**/FluxgateProperties$ReloadProperties$*.class</exclude>
                         <!-- Exclude new MissingRuleBehavior enum (covered by FluxgatePropertiesTest) -->
                         <exclude>**/FluxgateProperties$MissingRuleBehavior.class</exclude>
+                        <!-- Exclude WaitForRefillProperties (covered by FluxgatePropertiesTest) -->
+                        <exclude>**/FluxgateProperties$WaitForRefillProperties.class</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/autoconfigure/FluxgateFilterAutoConfiguration.java
+++ b/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/autoconfigure/FluxgateFilterAutoConfiguration.java
@@ -4,6 +4,9 @@ import java.util.Map;
 import org.fluxgate.core.handler.FluxgateRateLimitHandler;
 import org.fluxgate.spring.annotation.EnableFluxgateFilter;
 import org.fluxgate.spring.filter.FluxgateRateLimitFilter;
+import org.fluxgate.spring.filter.RequestContextCustomizer;
+import org.fluxgate.spring.properties.FluxgateProperties;
+import org.fluxgate.spring.properties.FluxgateProperties.WaitForRefillProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -12,6 +15,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -51,6 +55,7 @@ import org.springframework.util.StringUtils;
 @Configuration
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnClass(name = "jakarta.servlet.Filter")
+@EnableConfigurationProperties(FluxgateProperties.class)
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class FluxgateFilterAutoConfiguration {
 
@@ -59,13 +64,15 @@ public class FluxgateFilterAutoConfiguration {
   /**
    * Creates the FluxgateRateLimitFilter.
    *
-   * <p>Reads configuration from {@link EnableFluxgateFilter} annotation.
+   * <p>Reads configuration from {@link EnableFluxgateFilter} annotation and FluxgateProperties.
    */
   @Bean
   @ConditionalOnMissingBean(FluxgateRateLimitFilter.class)
   public FluxgateRateLimitFilter fluxgateRateLimitFilter(
       ApplicationContext applicationContext,
-      ObjectProvider<FluxgateRateLimitHandler> handlerProvider) {
+      ObjectProvider<FluxgateRateLimitHandler> handlerProvider,
+      ObjectProvider<RequestContextCustomizer> customizerProvider,
+      FluxgateProperties properties) {
 
     // Find the annotation
     EnableFluxgateFilter annotation = findEnableFluxgateFilterAnnotation(applicationContext);
@@ -85,11 +92,52 @@ public class FluxgateFilterAutoConfiguration {
     String[] includePatterns = annotation.includePatterns();
     String[] excludePatterns = annotation.excludePatterns();
 
+    // Get WAIT_FOR_REFILL configuration from properties
+    WaitForRefillProperties waitConfig = properties.getRatelimit().getWaitForRefill();
+
+    // Get optional RequestContextCustomizer (can be null)
+    RequestContextCustomizer contextCustomizer = resolveContextCustomizer(customizerProvider);
+
     log.info("Creating FluxgateRateLimitFilter");
     log.info("  Handler: {}", handler.getClass().getSimpleName());
     log.info("  Rule set ID: {}", StringUtils.hasText(ruleSetId) ? ruleSetId : "(not set)");
+    if (contextCustomizer != null) {
+      log.info("  RequestContext customizer: {}", contextCustomizer.getClass().getSimpleName());
+    }
 
-    return new FluxgateRateLimitFilter(handler, ruleSetId, includePatterns, excludePatterns);
+    return new FluxgateRateLimitFilter(
+        handler,
+        ruleSetId,
+        includePatterns,
+        excludePatterns,
+        waitConfig.isEnabled(),
+        waitConfig.getMaxWaitTimeMs(),
+        waitConfig.getMaxConcurrentWaits(),
+        contextCustomizer);
+  }
+
+  /**
+   * Resolves RequestContextCustomizer beans. If multiple customizers are registered, they are
+   * combined in order.
+   */
+  private RequestContextCustomizer resolveContextCustomizer(
+      ObjectProvider<RequestContextCustomizer> customizerProvider) {
+    RequestContextCustomizer[] customizers =
+        customizerProvider.orderedStream().toArray(RequestContextCustomizer[]::new);
+
+    if (customizers.length == 0) {
+      return null;
+    } else if (customizers.length == 1) {
+      return customizers[0];
+    } else {
+      // Combine multiple customizers
+      log.info("Combining {} RequestContextCustomizers", customizers.length);
+      RequestContextCustomizer combined = customizers[0];
+      for (int i = 1; i < customizers.length; i++) {
+        combined = combined.andThen(customizers[i]);
+      }
+      return combined;
+    }
   }
 
   /** Registers the FluxgateRateLimitFilter with the servlet container. */

--- a/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/autoconfigure/FluxgateMongoAutoConfiguration.java
+++ b/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/autoconfigure/FluxgateMongoAutoConfiguration.java
@@ -10,7 +10,6 @@ import org.fluxgate.adapter.mongo.health.MongoHealthCheckerImpl;
 import org.fluxgate.adapter.mongo.repository.MongoRateLimitRuleRepository;
 import org.fluxgate.adapter.mongo.rule.MongoRuleSetProvider;
 import org.fluxgate.core.key.KeyResolver;
-import org.fluxgate.core.key.RateLimitKey;
 import org.fluxgate.core.metrics.RateLimitMetricsRecorder;
 import org.fluxgate.core.spi.RateLimitRuleRepository;
 import org.fluxgate.core.spi.RateLimitRuleSetProvider;
@@ -121,15 +120,25 @@ public class FluxgateMongoAutoConfiguration {
   }
 
   /**
-   * Creates a default KeyResolver that extracts client IP.
+   * Creates a default KeyResolver that resolves keys based on the rule's LimitScope.
+   *
+   * <p>The default implementation {@link org.fluxgate.core.key.LimitScopeKeyResolver} uses:
+   *
+   * <ul>
+   *   <li>GLOBAL - Single bucket for all requests
+   *   <li>PER_IP - One bucket per client IP address
+   *   <li>PER_USER - One bucket per user ID (from RequestContext.userId)
+   *   <li>PER_API_KEY - One bucket per API key (from RequestContext.apiKey)
+   *   <li>CUSTOM - Custom resolution via attributes
+   * </ul>
    *
    * <p>Users can override this bean with a custom KeyResolver.
    */
   @Bean(name = "fluxgateKeyResolver")
   @ConditionalOnMissingBean(KeyResolver.class)
   public KeyResolver fluxgateKeyResolver() {
-    log.info("Creating default KeyResolver (extracts client IP)");
-    return context -> new RateLimitKey(context.getClientIp());
+    log.info("Creating default LimitScopeKeyResolver (resolves key based on rule's LimitScope)");
+    return new org.fluxgate.core.key.LimitScopeKeyResolver();
   }
 
   /**

--- a/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/filter/FluxgateRateLimitFilter.java
+++ b/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/filter/FluxgateRateLimitFilter.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import org.fluxgate.core.context.RequestContext;
 import org.fluxgate.core.handler.FluxgateRateLimitHandler;
 import org.fluxgate.core.handler.RateLimitResponse;
@@ -42,6 +44,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  *   <li>Configurable include/exclude URL patterns
  *   <li>Sets standard rate limit HTTP headers
  *   <li>Returns 429 Too Many Requests when limit exceeded
+ *   <li>Supports WAIT_FOR_REFILL policy with semaphore-based concurrency control
  * </ul>
  */
 public class FluxgateRateLimitFilter extends OncePerRequestFilter {
@@ -54,8 +57,16 @@ public class FluxgateRateLimitFilter extends OncePerRequestFilter {
   private final String[] excludePatterns;
   private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
+  // WAIT_FOR_REFILL configuration
+  private final boolean waitForRefillEnabled;
+  private final long maxWaitTimeMs;
+  private final Semaphore waitSemaphore;
+
+  // RequestContext customization
+  private final RequestContextCustomizer contextCustomizer;
+
   /**
-   * Creates a new FluxgateRateLimitFilter.
+   * Creates a new FluxgateRateLimitFilter with default settings (WAIT_FOR_REFILL disabled).
    *
    * @param handler The rate limit handler (required)
    * @param ruleSetId Default rule set ID to use
@@ -67,10 +78,70 @@ public class FluxgateRateLimitFilter extends OncePerRequestFilter {
       String ruleSetId,
       String[] includePatterns,
       String[] excludePatterns) {
+    this(handler, ruleSetId, includePatterns, excludePatterns, false, 5000, 100, null);
+  }
+
+  /**
+   * Creates a new FluxgateRateLimitFilter with WAIT_FOR_REFILL configuration.
+   *
+   * @param handler The rate limit handler (required)
+   * @param ruleSetId Default rule set ID to use
+   * @param includePatterns URL patterns to include
+   * @param excludePatterns URL patterns to exclude
+   * @param waitForRefillEnabled Enable WAIT_FOR_REFILL behavior
+   * @param maxWaitTimeMs Maximum time to wait for token refill
+   * @param maxConcurrentWaits Maximum concurrent waiting requests (semaphore permits)
+   */
+  public FluxgateRateLimitFilter(
+      FluxgateRateLimitHandler handler,
+      String ruleSetId,
+      String[] includePatterns,
+      String[] excludePatterns,
+      boolean waitForRefillEnabled,
+      long maxWaitTimeMs,
+      int maxConcurrentWaits) {
+    this(
+        handler,
+        ruleSetId,
+        includePatterns,
+        excludePatterns,
+        waitForRefillEnabled,
+        maxWaitTimeMs,
+        maxConcurrentWaits,
+        null);
+  }
+
+  /**
+   * Creates a new FluxgateRateLimitFilter with full configuration including RequestContext
+   * customization.
+   *
+   * @param handler The rate limit handler (required)
+   * @param ruleSetId Default rule set ID to use
+   * @param includePatterns URL patterns to include
+   * @param excludePatterns URL patterns to exclude
+   * @param waitForRefillEnabled Enable WAIT_FOR_REFILL behavior
+   * @param maxWaitTimeMs Maximum time to wait for token refill
+   * @param maxConcurrentWaits Maximum concurrent waiting requests (semaphore permits)
+   * @param contextCustomizer Customizer for RequestContext (nullable)
+   */
+  public FluxgateRateLimitFilter(
+      FluxgateRateLimitHandler handler,
+      String ruleSetId,
+      String[] includePatterns,
+      String[] excludePatterns,
+      boolean waitForRefillEnabled,
+      long maxWaitTimeMs,
+      int maxConcurrentWaits,
+      RequestContextCustomizer contextCustomizer) {
     this.handler = Objects.requireNonNull(handler, "handler must not be null");
     this.ruleSetId = Objects.requireNonNull(ruleSetId, "ruleSetId must not be null");
     this.includePatterns = includePatterns != null ? includePatterns : new String[0];
     this.excludePatterns = excludePatterns != null ? excludePatterns : new String[0];
+    this.waitForRefillEnabled = waitForRefillEnabled;
+    this.maxWaitTimeMs = maxWaitTimeMs;
+    this.waitSemaphore = new Semaphore(maxConcurrentWaits);
+    this.contextCustomizer =
+        contextCustomizer != null ? contextCustomizer : RequestContextCustomizer.identity();
 
     if (log.isDebugEnabled()) {
       log.debug("FluxgateRateLimitFilter initialized");
@@ -78,6 +149,14 @@ public class FluxgateRateLimitFilter extends OncePerRequestFilter {
       log.debug("  Rule set ID: {}", ruleSetId);
       log.debug("  Include patterns: {}", Arrays.toString(this.includePatterns));
       log.debug("  Exclude patterns: {}", Arrays.toString(this.excludePatterns));
+      log.debug("  WAIT_FOR_REFILL enabled: {}", waitForRefillEnabled);
+      if (waitForRefillEnabled) {
+        log.debug("  Max wait time: {} ms", maxWaitTimeMs);
+        log.debug("  Max concurrent waits: {}", maxConcurrentWaits);
+      }
+      log.debug(
+          "  RequestContext customizer: {}",
+          contextCustomizer != null ? contextCustomizer.getClass().getSimpleName() : "default");
     }
   }
 
@@ -158,6 +237,9 @@ public class FluxgateRateLimitFilter extends OncePerRequestFilter {
         MDC.put(MdcKeys.STATUS_CODE, String.valueOf(response.getStatus()));
         MDC.put(MdcKeys.DURATION_MS, String.valueOf(System.currentTimeMillis() - startTimeMs));
         log.info("Request completed");
+      } else if (shouldWaitForRefill(result)) {
+        // WAIT_FOR_REFILL policy: wait for tokens and retry
+        handleWaitForRefill(request, response, filterChain, context, result);
       } else {
         MDC.put(MdcKeys.RETRY_AFTER_MS, String.valueOf(result.getRetryAfterMillis()));
         MDC.put(MdcKeys.STATUS_CODE, "429");
@@ -179,19 +261,149 @@ public class FluxgateRateLimitFilter extends OncePerRequestFilter {
     }
   }
 
-  /** Builds a RequestContext from the HTTP request. */
+  /**
+   * Check if we should wait for refill based on response policy and configuration.
+   *
+   * @param result The rate limit response
+   * @return true if we should wait for refill
+   */
+  private boolean shouldWaitForRefill(RateLimitResponse result) {
+    return waitForRefillEnabled && result.shouldWaitForRefill();
+  }
+
+  /**
+   * Handle WAIT_FOR_REFILL policy by waiting for tokens and retrying.
+   *
+   * <p>Uses a semaphore to limit the number of concurrent waiting requests. If the semaphore cannot
+   * be acquired, or if the wait time exceeds the maximum, the request is rejected immediately.
+   */
+  private void handleWaitForRefill(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain,
+      RequestContext context,
+      RateLimitResponse result)
+      throws ServletException, IOException {
+
+    long waitTimeMs = result.getRetryAfterMillis();
+    String path = request.getRequestURI();
+    String method = request.getMethod();
+
+    // Check if wait time exceeds maximum allowed
+    if (waitTimeMs > maxWaitTimeMs) {
+      log.info(
+          "Wait time {} ms exceeds max {} ms, rejecting: {} {} from {}",
+          waitTimeMs,
+          maxWaitTimeMs,
+          method,
+          path,
+          context.getClientIp());
+      handleRateLimitExceeded(response, result);
+      return;
+    }
+
+    // Try to acquire semaphore permit (non-blocking)
+    if (!waitSemaphore.tryAcquire()) {
+      log.info(
+          "Too many concurrent waits, rejecting: {} {} from {}",
+          method,
+          path,
+          context.getClientIp());
+      handleRateLimitExceeded(response, result);
+      return;
+    }
+
+    try {
+      log.debug(
+          "Waiting {} ms for token refill: {} {} from {}",
+          waitTimeMs,
+          method,
+          path,
+          context.getClientIp());
+
+      // Sleep and wait for tokens to become available
+      TimeUnit.MILLISECONDS.sleep(waitTimeMs);
+
+      // Retry rate limit check after waiting
+      RateLimitResponse retryResult = handler.tryConsume(context, ruleSetId);
+      addRateLimitHeaders(response, retryResult);
+
+      if (retryResult.isAllowed()) {
+        log.debug(
+            "Request allowed after wait: {} {} from {} (remaining: {})",
+            method,
+            path,
+            context.getClientIp(),
+            retryResult.getRemainingTokens());
+        filterChain.doFilter(request, response);
+      } else {
+        // Still rejected after waiting - reject the request
+        log.info(
+            "Request still rate limited after wait: {} {} from {} (retry after: {} ms)",
+            method,
+            path,
+            context.getClientIp(),
+            retryResult.getRetryAfterMillis());
+        handleRateLimitExceeded(response, retryResult);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn("Wait interrupted for: {} {} from {}", method, path, context.getClientIp());
+      handleRateLimitExceeded(response, result);
+    } finally {
+      waitSemaphore.release();
+    }
+  }
+
+  /**
+   * Builds a RequestContext from the HTTP request with full tracking information.
+   *
+   * <p>This method first populates default values, then applies any registered
+   * RequestContextCustomizer to allow users to override or add custom fields.
+   */
   private RequestContext buildRequestContext(HttpServletRequest request) {
     String clientIp = extractClientIp(request);
     String userId = request.getHeader(Headers.USER_ID);
     String apiKey = request.getHeader(Headers.API_KEY);
 
-    return RequestContext.builder()
-        .clientIp(clientIp)
-        .userId(userId)
-        .apiKey(apiKey)
-        .endpoint(request.getRequestURI())
-        .method(request.getMethod())
-        .build();
+    // Build the default context with core fields
+    RequestContext.Builder builder =
+        RequestContext.builder()
+            .clientIp(clientIp)
+            .userId(userId)
+            .apiKey(apiKey)
+            .endpoint(request.getRequestURI())
+            .method(request.getMethod());
+
+    // Collect HTTP headers for tracking
+    collectHeaders(builder, request);
+
+    // Apply customizer to allow user overrides and custom attributes
+    builder = contextCustomizer.customize(builder, request);
+
+    return builder.build();
+  }
+
+  /** Collects all HTTP headers from the request. */
+  private void collectHeaders(RequestContext.Builder builder, HttpServletRequest request) {
+    java.util.Enumeration<String> headerNames = request.getHeaderNames();
+    if (headerNames != null) {
+      while (headerNames.hasMoreElements()) {
+        String headerName = headerNames.nextElement();
+        builder.header(headerName, request.getHeader(headerName));
+      }
+    }
+
+    // Add servlet-specific info that's not in headers
+    long contentLength = request.getContentLengthLong();
+    if (contentLength > 0 && builder.getHeader("Content-Length") == null) {
+      builder.header("Content-Length", String.valueOf(contentLength));
+    }
+
+    String sessionId = request.getRequestedSessionId();
+    if (sessionId != null) {
+      builder.header("Session-Id", sessionId);
+    }
   }
 
   /**

--- a/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/filter/RequestContextCustomizer.java
+++ b/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/filter/RequestContextCustomizer.java
@@ -1,0 +1,80 @@
+package org.fluxgate.spring.filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.fluxgate.core.context.RequestContext;
+
+/**
+ * Interface for customizing how RequestContext is built from HTTP requests.
+ *
+ * <p>Implement this interface to customize:
+ *
+ * <ul>
+ *   <li>Client IP extraction (e.g., custom proxy headers)
+ *   <li>User identification (e.g., from JWT tokens)
+ *   <li>Custom attributes (e.g., tenant ID, region)
+ *   <li>Any other RequestContext fields
+ * </ul>
+ *
+ * <p>Example implementation:
+ *
+ * <pre>{@code
+ * @Component
+ * public class MyRequestContextCustomizer implements RequestContextCustomizer {
+ *
+ *     @Override
+ *     public RequestContext.Builder customize(RequestContext.Builder builder,
+ *                                              HttpServletRequest request) {
+ *         // Extract tenant from header
+ *         String tenantId = request.getHeader("X-Tenant-Id");
+ *         builder.attribute("tenantId", tenantId);
+ *
+ *         // Override client IP extraction
+ *         String clientIp = extractFromCloudflare(request);
+ *         builder.clientIp(clientIp);
+ *
+ *         return builder;
+ *     }
+ *
+ *     private String extractFromCloudflare(HttpServletRequest request) {
+ *         String cfIp = request.getHeader("CF-Connecting-IP");
+ *         return cfIp != null ? cfIp : request.getRemoteAddr();
+ *     }
+ * }
+ * }</pre>
+ *
+ * @see FluxgateRateLimitFilter
+ */
+@FunctionalInterface
+public interface RequestContextCustomizer {
+
+  /**
+   * Customize the RequestContext builder before the context is built.
+   *
+   * <p>The builder is already populated with default values extracted from the request. You can
+   * override any values or add custom attributes.
+   *
+   * @param builder The pre-populated RequestContext builder
+   * @param request The HTTP request
+   * @return The customized builder (usually the same instance)
+   */
+  RequestContext.Builder customize(RequestContext.Builder builder, HttpServletRequest request);
+
+  /**
+   * Default no-op customizer that returns the builder unchanged.
+   *
+   * @return A customizer that does nothing
+   */
+  static RequestContextCustomizer identity() {
+    return (builder, request) -> builder;
+  }
+
+  /**
+   * Combines this customizer with another, applying this one first.
+   *
+   * @param after The customizer to apply after this one
+   * @return A combined customizer
+   */
+  default RequestContextCustomizer andThen(RequestContextCustomizer after) {
+    return (builder, request) -> after.customize(this.customize(builder, request), request);
+  }
+}

--- a/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/properties/FluxgateProperties.java
+++ b/fluxgate-spring-boot-starter/src/main/java/org/fluxgate/spring/properties/FluxgateProperties.java
@@ -352,6 +352,10 @@ public class FluxgateProperties {
     /** Enable rate limit response headers. X-RateLimit-Limit, X-RateLimit-Remaining, etc. */
     private boolean includeHeaders = true;
 
+    /** WAIT_FOR_REFILL policy configuration. */
+    @NestedConfigurationProperty
+    private WaitForRefillProperties waitForRefill = new WaitForRefillProperties();
+
     public boolean isEnabled() {
       return enabled;
     }
@@ -440,6 +444,14 @@ public class FluxgateProperties {
     public boolean isDenyWhenRuleMissing() {
       return missingRuleBehavior == MissingRuleBehavior.DENY;
     }
+
+    public WaitForRefillProperties getWaitForRefill() {
+      return waitForRefill;
+    }
+
+    public void setWaitForRefill(WaitForRefillProperties waitForRefill) {
+      this.waitForRefill = waitForRefill;
+    }
   }
 
   /** Behavior when no matching rate limit rule is found. */
@@ -448,6 +460,69 @@ public class FluxgateProperties {
     ALLOW,
     /** Deny the request (strict mode, fail-closed). */
     DENY
+  }
+
+  /**
+   * Configuration for WAIT_FOR_REFILL policy.
+   *
+   * <p>When a rule has OnLimitExceedPolicy.WAIT_FOR_REFILL, the filter will wait for tokens to
+   * become available instead of immediately rejecting the request.
+   *
+   * <p>Example configuration:
+   *
+   * <pre>
+   * fluxgate:
+   *   ratelimit:
+   *     waitForRefill:
+   *       enabled: true
+   *       maxWaitTimeMs: 5000
+   *       maxConcurrentWaits: 100
+   * </pre>
+   */
+  public static class WaitForRefillProperties {
+
+    /**
+     * Enable WAIT_FOR_REFILL behavior. When false, requests exceeding the limit are immediately
+     * rejected even if the rule has WAIT_FOR_REFILL policy.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Maximum time to wait for token refill in milliseconds. If the required wait time exceeds this
+     * value, the request is rejected immediately. Default: 5000ms (5 seconds).
+     */
+    private long maxWaitTimeMs = 5000;
+
+    /**
+     * Maximum number of concurrent waiting requests. Uses a semaphore to limit how many requests
+     * can wait at the same time. This prevents thread pool exhaustion. When exceeded, requests are
+     * rejected immediately. Default: 100.
+     */
+    private int maxConcurrentWaits = 100;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public long getMaxWaitTimeMs() {
+      return maxWaitTimeMs;
+    }
+
+    public void setMaxWaitTimeMs(long maxWaitTimeMs) {
+      this.maxWaitTimeMs = maxWaitTimeMs;
+    }
+
+    public int getMaxConcurrentWaits() {
+      return maxConcurrentWaits;
+    }
+
+    public void setMaxConcurrentWaits(int maxConcurrentWaits) {
+      this.maxConcurrentWaits = maxConcurrentWaits;
+    }
   }
 
   /** Metrics configuration for Prometheus/Micrometer integration. */

--- a/fluxgate-spring-boot-starter/src/test/java/org/fluxgate/spring/autoconfigure/LazyMetricsMongoRuleSetProviderTest.java
+++ b/fluxgate-spring-boot-starter/src/test/java/org/fluxgate/spring/autoconfigure/LazyMetricsMongoRuleSetProviderTest.java
@@ -35,7 +35,7 @@ class LazyMetricsMongoRuleSetProviderTest {
 
   @BeforeEach
   void setUp() {
-    keyResolver = context -> new RateLimitKey("test-key");
+    keyResolver = (context, rule) -> new RateLimitKey("test-key");
     provider =
         new LazyMetricsMongoRuleSetProvider(ruleRepository, keyResolver, metricsRecorderProvider);
   }

--- a/fluxgate-spring-boot-starter/src/test/java/org/fluxgate/spring/filter/RequestContextCustomizerTest.java
+++ b/fluxgate-spring-boot-starter/src/test/java/org/fluxgate/spring/filter/RequestContextCustomizerTest.java
@@ -1,0 +1,205 @@
+package org.fluxgate.spring.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.fluxgate.core.context.RequestContext;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link RequestContextCustomizer}. */
+class RequestContextCustomizerTest {
+
+  @Test
+  void identity_shouldReturnBuilderUnchanged() {
+    // Given
+    RequestContextCustomizer customizer = RequestContextCustomizer.identity();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    RequestContext.Builder builder =
+        RequestContext.builder().clientIp("192.168.1.1").endpoint("/api/test").method("GET");
+
+    // When
+    RequestContext.Builder result = customizer.customize(builder, request);
+
+    // Then
+    assertThat(result).isSameAs(builder);
+    RequestContext context = result.build();
+    assertThat(context.getClientIp()).isEqualTo("192.168.1.1");
+  }
+
+  @Test
+  void andThen_shouldCombineCustomizers() {
+    // Given
+    RequestContextCustomizer first =
+        (builder, req) -> {
+          builder.attribute("first", "value1");
+          return builder;
+        };
+
+    RequestContextCustomizer second =
+        (builder, req) -> {
+          builder.attribute("second", "value2");
+          return builder;
+        };
+
+    RequestContextCustomizer combined = first.andThen(second);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    RequestContext.Builder builder = RequestContext.builder().clientIp("192.168.1.1");
+
+    // When
+    RequestContext.Builder result = combined.customize(builder, request);
+
+    // Then
+    RequestContext context = result.build();
+    assertThat(context.getAttribute("first")).isEqualTo("value1");
+    assertThat(context.getAttribute("second")).isEqualTo("value2");
+  }
+
+  @Test
+  void customizer_canOverrideExistingValues() {
+    // Given
+    RequestContextCustomizer customizer =
+        (builder, req) -> {
+          String cfIp = req.getHeader("CF-Connecting-IP");
+          if (cfIp != null) {
+            builder.clientIp(cfIp);
+          }
+          return builder;
+        };
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader("CF-Connecting-IP")).thenReturn("203.0.113.50");
+
+    RequestContext.Builder builder =
+        RequestContext.builder().clientIp("10.0.0.1").endpoint("/api/test").method("GET");
+
+    // When
+    RequestContext.Builder result = customizer.customize(builder, request);
+
+    // Then
+    RequestContext context = result.build();
+    assertThat(context.getClientIp()).isEqualTo("203.0.113.50");
+  }
+
+  @Test
+  void customizer_canReadBuilderCurrentValues() {
+    // Given
+    RequestContextCustomizer customizer =
+        (builder, req) -> {
+          // Read current values from builder
+          String currentIp = builder.getClientIp();
+          String currentEndpoint = builder.getEndpoint();
+
+          // Add attributes based on current values
+          builder.attribute("originalIp", currentIp);
+          builder.attribute("originalEndpoint", currentEndpoint);
+
+          return builder;
+        };
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    RequestContext.Builder builder =
+        RequestContext.builder().clientIp("192.168.1.100").endpoint("/api/users").method("GET");
+
+    // When
+    RequestContext.Builder result = customizer.customize(builder, request);
+
+    // Then
+    RequestContext context = result.build();
+    assertThat(context.getAttribute("originalIp")).isEqualTo("192.168.1.100");
+    assertThat(context.getAttribute("originalEndpoint")).isEqualTo("/api/users");
+  }
+
+  @Test
+  void customizer_canAddMultipleHeaders() {
+    // Given
+    RequestContextCustomizer customizer =
+        (builder, req) -> {
+          builder.header("X-Custom-1", "value1");
+          builder.header("X-Custom-2", "value2");
+          return builder;
+        };
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    RequestContext.Builder builder = RequestContext.builder().clientIp("192.168.1.1");
+
+    // When
+    RequestContext.Builder result = customizer.customize(builder, request);
+
+    // Then
+    RequestContext context = result.build();
+    assertThat(context.getHeader("X-Custom-1")).isEqualTo("value1");
+    assertThat(context.getHeader("X-Custom-2")).isEqualTo("value2");
+  }
+
+  @Test
+  void customizer_canRemoveHeaders() {
+    // Given
+    RequestContextCustomizer customizer =
+        (builder, req) -> {
+          // Remove sensitive headers
+          builder.getHeaders().remove("Authorization");
+          builder.getHeaders().remove("Cookie");
+          return builder;
+        };
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    RequestContext.Builder builder =
+        RequestContext.builder()
+            .clientIp("192.168.1.1")
+            .header("Authorization", "Bearer secret-token")
+            .header("Cookie", "session=abc123")
+            .header("Accept", "application/json");
+
+    // When
+    RequestContext.Builder result = customizer.customize(builder, request);
+
+    // Then
+    RequestContext context = result.build();
+    assertThat(context.getHeader("Authorization")).isNull();
+    assertThat(context.getHeader("Cookie")).isNull();
+    assertThat(context.getHeader("Accept")).isEqualTo("application/json");
+  }
+
+  @Test
+  void andThen_shouldApplyInOrder() {
+    // Given - First customizer sets value, second modifies it
+    RequestContextCustomizer first =
+        (builder, req) -> {
+          builder.attribute("counter", 1);
+          return builder;
+        };
+
+    RequestContextCustomizer second =
+        (builder, req) -> {
+          Integer current = (Integer) builder.getAttribute("counter");
+          builder.attribute("counter", current + 1);
+          return builder;
+        };
+
+    RequestContextCustomizer third =
+        (builder, req) -> {
+          Integer current = (Integer) builder.getAttribute("counter");
+          builder.attribute("counter", current + 1);
+          return builder;
+        };
+
+    RequestContextCustomizer combined = first.andThen(second).andThen(third);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    RequestContext.Builder builder = RequestContext.builder().clientIp("192.168.1.1");
+
+    // When
+    RequestContext.Builder result = combined.customize(builder, request);
+
+    // Then
+    RequestContext context = result.build();
+    assertThat(context.getAttribute("counter")).isEqualTo(3);
+  }
+}

--- a/fluxgate-spring-boot-starter/src/test/java/org/fluxgate/spring/properties/FluxgatePropertiesTest.java
+++ b/fluxgate-spring-boot-starter/src/test/java/org/fluxgate/spring/properties/FluxgatePropertiesTest.java
@@ -161,6 +161,34 @@ class FluxgatePropertiesTest {
   }
 
   @Test
+  void shouldSetWaitForRefillProperties() {
+    FluxgateProperties properties = new FluxgateProperties();
+    FluxgateProperties.RateLimitProperties rateLimit = properties.getRatelimit();
+    FluxgateProperties.WaitForRefillProperties waitForRefill = rateLimit.getWaitForRefill();
+
+    // Default values
+    assertThat(waitForRefill.isEnabled()).isFalse();
+    assertThat(waitForRefill.getMaxWaitTimeMs()).isEqualTo(5000);
+    assertThat(waitForRefill.getMaxConcurrentWaits()).isEqualTo(100);
+
+    // Set custom values
+    waitForRefill.setEnabled(true);
+    waitForRefill.setMaxWaitTimeMs(10000);
+    waitForRefill.setMaxConcurrentWaits(50);
+
+    assertThat(waitForRefill.isEnabled()).isTrue();
+    assertThat(waitForRefill.getMaxWaitTimeMs()).isEqualTo(10000);
+    assertThat(waitForRefill.getMaxConcurrentWaits()).isEqualTo(50);
+
+    // Set via parent
+    FluxgateProperties.WaitForRefillProperties newWaitForRefill =
+        new FluxgateProperties.WaitForRefillProperties();
+    newWaitForRefill.setEnabled(false);
+    rateLimit.setWaitForRefill(newWaitForRefill);
+    assertThat(rateLimit.getWaitForRefill().isEnabled()).isFalse();
+  }
+
+  @Test
   void shouldHaveDefaultMissingRuleBehavior() {
     FluxgateProperties properties = new FluxgateProperties();
     FluxgateProperties.RateLimitProperties rateLimit = properties.getRatelimit();
@@ -220,38 +248,89 @@ class FluxgatePropertiesTest {
   }
 
   @Test
+  void shouldSetActuatorProperties() {
+    FluxgateProperties properties = new FluxgateProperties();
+    FluxgateProperties.ActuatorProperties actuator = properties.getActuator();
+    FluxgateProperties.ActuatorProperties.HealthProperties health = actuator.getHealth();
+
+    // Default values
+    assertThat(health.isEnabled()).isTrue();
+
+    // Set custom values
+    health.setEnabled(false);
+    assertThat(health.isEnabled()).isFalse();
+
+    // Set health properties via setter
+    FluxgateProperties.ActuatorProperties.HealthProperties newHealth =
+        new FluxgateProperties.ActuatorProperties.HealthProperties();
+    newHealth.setEnabled(true);
+    actuator.setHealth(newHealth);
+    assertThat(actuator.getHealth().isEnabled()).isTrue();
+  }
+
+  @Test
   void shouldSetMetricsProperties() {
     FluxgateProperties properties = new FluxgateProperties();
     FluxgateProperties.MetricsProperties metrics = properties.getMetrics();
 
-    // Test defaults
+    // Default values
     assertThat(metrics.isEnabled()).isTrue();
     assertThat(metrics.isIncludeEndpoint()).isTrue();
 
-    // Test setters
+    // Set custom values
     metrics.setEnabled(false);
     metrics.setIncludeEndpoint(false);
 
     assertThat(metrics.isEnabled()).isFalse();
     assertThat(metrics.isIncludeEndpoint()).isFalse();
+
+    // Set via parent
+    FluxgateProperties.MetricsProperties newMetrics = new FluxgateProperties.MetricsProperties();
+    newMetrics.setEnabled(true);
+    properties.setMetrics(newMetrics);
+    assertThat(properties.getMetrics().isEnabled()).isTrue();
+
+    // Set actuator via parent
+    FluxgateProperties.ActuatorProperties newActuator = new FluxgateProperties.ActuatorProperties();
+    properties.setActuator(newActuator);
+    assertThat(properties.getActuator()).isNotNull();
   }
 
   @Test
-  void shouldSetActuatorProperties() {
+  void shouldSetRedisClusterProperties() {
     FluxgateProperties properties = new FluxgateProperties();
-    FluxgateProperties.ActuatorProperties actuator = properties.getActuator();
+    FluxgateProperties.RedisProperties redis = properties.getRedis();
 
-    // Test defaults
-    assertThat(actuator.getHealth()).isNotNull();
-    assertThat(actuator.getHealth().isEnabled()).isTrue();
+    // Test mode
+    redis.setMode("cluster");
+    assertThat(redis.getMode()).isEqualTo("cluster");
+    assertThat(redis.getEffectiveMode()).isEqualTo("cluster");
+    assertThat(redis.isClusterMode()).isTrue();
 
-    // Test setters
-    FluxgateProperties.ActuatorProperties.HealthProperties health =
-        new FluxgateProperties.ActuatorProperties.HealthProperties();
-    health.setEnabled(false);
-    actuator.setHealth(health);
+    // Test standalone mode
+    redis.setMode("standalone");
+    assertThat(redis.getEffectiveMode()).isEqualTo("standalone");
+    assertThat(redis.isClusterMode()).isFalse();
 
-    assertThat(actuator.getHealth().isEnabled()).isFalse();
+    // Test auto mode with single URI
+    redis.setMode("auto");
+    redis.setUri("redis://localhost:6379");
+    assertThat(redis.getEffectiveMode()).isEqualTo("standalone");
+
+    // Test auto mode with multiple URIs (comma-separated)
+    redis.setUri("redis://node1:6379,redis://node2:6379");
+    assertThat(redis.getEffectiveMode()).isEqualTo("cluster");
+
+    // Test timeout
+    redis.setTimeoutMs(10000);
+    assertThat(redis.getTimeoutMs()).isEqualTo(10000);
+  }
+
+  @Test
+  void shouldHaveCorrectDdlAutoValues() {
+    // Test all enum values
+    assertThat(FluxgateProperties.DdlAuto.VALIDATE.name()).isEqualTo("VALIDATE");
+    assertThat(FluxgateProperties.DdlAuto.CREATE.name()).isEqualTo("CREATE");
   }
 
   @Test

--- a/fluxgate-testkit/pom.xml
+++ b/fluxgate-testkit/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.openfluxgate</groupId>
         <artifactId>fluxgate</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>fluxgate-testkit</artifactId>

--- a/fluxgate-testkit/src/test/java/org/fluxgate/testkit/integration/MongoRedisRateLimitIntegrationTest.java
+++ b/fluxgate-testkit/src/test/java/org/fluxgate/testkit/integration/MongoRedisRateLimitIntegrationTest.java
@@ -21,8 +21,7 @@ import org.fluxgate.core.config.OnLimitExceedPolicy;
 import org.fluxgate.core.config.RateLimitBand;
 import org.fluxgate.core.config.RateLimitRule;
 import org.fluxgate.core.context.RequestContext;
-import org.fluxgate.core.key.KeyResolver;
-import org.fluxgate.core.key.RateLimitKey;
+import org.fluxgate.core.key.LimitScopeKeyResolver;
 import org.fluxgate.core.ratelimiter.RateLimitResult;
 import org.fluxgate.core.ratelimiter.RateLimitRuleSet;
 import org.fluxgate.redis.RedisRateLimiter;
@@ -97,9 +96,8 @@ class MongoRedisRateLimitIntegrationTest {
 
     ruleRepository = new MongoRateLimitRuleRepository(ruleCollection);
 
-    // KeyResolver for PER_IP: extracts client IP from RequestContext
-    KeyResolver ipKeyResolver = context -> new RateLimitKey(context.getClientIp());
-    ruleSetProvider = new MongoRuleSetProvider(ruleRepository, ipKeyResolver);
+    // KeyResolver: uses LimitScopeKeyResolver for scope-based key resolution
+    ruleSetProvider = new MongoRuleSetProvider(ruleRepository, new LimitScopeKeyResolver());
 
     // 2. Setup Redis
     System.out.println("Connecting to Redis: " + REDIS_URI);

--- a/fluxgate-testkit/src/test/java/org/fluxgate/testkit/redis/MongoRedisRateLimitIntegrationTest.java
+++ b/fluxgate-testkit/src/test/java/org/fluxgate/testkit/redis/MongoRedisRateLimitIntegrationTest.java
@@ -26,8 +26,7 @@ import org.fluxgate.core.config.OnLimitExceedPolicy;
 import org.fluxgate.core.config.RateLimitBand;
 import org.fluxgate.core.config.RateLimitRule;
 import org.fluxgate.core.context.RequestContext;
-import org.fluxgate.core.key.KeyResolver;
-import org.fluxgate.core.key.RateLimitKey;
+import org.fluxgate.core.key.LimitScopeKeyResolver;
 import org.fluxgate.core.ratelimiter.RateLimitResult;
 import org.fluxgate.core.ratelimiter.RateLimitRuleSet;
 import org.fluxgate.redis.RedisRateLimiter;
@@ -113,10 +112,8 @@ class MongoRedisRateLimitIntegrationTest {
     // Create repository and provider
     ruleRepository = new MongoRateLimitRuleRepository(ruleCollection);
 
-    // KeyResolver: extracts client IP from RequestContext
-    // NOTE: If your KeyResolver interface is different, adjust accordingly
-    KeyResolver ipKeyResolver = context -> new RateLimitKey(context.getClientIp());
-    ruleSetProvider = new MongoRuleSetProvider(ruleRepository, ipKeyResolver);
+    // KeyResolver: uses LimitScopeKeyResolver for scope-based key resolution
+    ruleSetProvider = new MongoRuleSetProvider(ruleRepository, new LimitScopeKeyResolver());
 
     System.out.println("[MongoDB] Connected successfully");
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>io.github.openfluxgate</groupId>
     <artifactId>fluxgate</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <packaging>pom</packaging>
 
     <name>FluxGate</name>


### PR DESCRIPTION
## [fluxgate] Release/0.3.0
- Release Note : https://github.com/OpenFluxGate/fluxgate/releases/tag/v0.3.0
- this version is partial of #22 

###  New Feature
- Multiple filters
- RequestContextCustomizer
- composite key support

## Detail Note
  - Add LimitScopeKeyResolver for scope-based rate limit key resolution
    - GLOBAL, PER_IP, PER_USER, PER_API_KEY, CUSTOM scopes
  - Change KeyResolver interface to accept RateLimitRule parameter
  - Add composite key (IP+User) support via CUSTOM scope with keyStrategyId
  - Update Bucket4jRateLimiter and RedisRateLimiter for per-rule key resolution
  - Add composite key sample endpoint (/api/test/composite)
  - Update README.md and README.ko.md with LimitScope documentation
  - Add Javadoc to RequestContext and RateLimitRuleSetProvider
  - Add MultipleFiltersConfig for multiple rate limit filters with different rule sets
  - Add RequestContextCustomizer for customizing RequestContext before rate limiting
  - Add RateLimitMetricsRecorder injection to MongoRuleSetProvider for event logging
  - Update standalone sample with multi-filter demonstration (2 filters, 3 rules)
  - Add tests for RequestContext, RateLimitResponse, and FluxgateProperties
  - Update README with architecture and usage documentation