### PR TITLE
fix: handle NOSCRIPT error when Redis restarts

### DIFF
--- a/fluxgate-redis-ratelimiter/src/main/java/org/fluxgate/redis/connection/ClusterRedisConnection.java
+++ b/fluxgate-redis-ratelimiter/src/main/java/org/fluxgate/redis/connection/ClusterRedisConnection.java
@@ -134,6 +134,18 @@ public class ClusterRedisConnection implements RedisConnectionProvider {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
+  public <T> T eval(String script, String[] keys, String[] args) {
+    Objects.requireNonNull(script, "script must not be null");
+    Objects.requireNonNull(keys, "keys must not be null");
+    Objects.requireNonNull(args, "args must not be null");
+
+    // Lettuce cluster client automatically routes EVAL to the correct node
+    // based on the key's slot
+    return (T) commands.eval(script, ScriptOutputType.MULTI, keys, args);
+  }
+
+  @Override
   public boolean hset(String key, String field, String value) {
     return commands.hset(key, field, value);
   }

--- a/fluxgate-redis-ratelimiter/src/main/java/org/fluxgate/redis/connection/RedisConnectionProvider.java
+++ b/fluxgate-redis-ratelimiter/src/main/java/org/fluxgate/redis/connection/RedisConnectionProvider.java
@@ -44,8 +44,22 @@ public interface RedisConnectionProvider extends AutoCloseable {
    * @param args the arguments passed to the script
    * @param <T> the return type
    * @return the script execution result
+   * @throws io.lettuce.core.RedisNoScriptException if the script is not cached in Redis
    */
   <T> T evalsha(String sha, String[] keys, String[] args);
+
+  /**
+   * Executes a Lua script using EVAL.
+   *
+   * <p>This is less efficient than EVALSHA but useful as a fallback when the script is not cached.
+   *
+   * @param script the Lua script content
+   * @param keys the keys used by the script
+   * @param args the arguments passed to the script
+   * @param <T> the return type
+   * @return the script execution result
+   */
+  <T> T eval(String script, String[] keys, String[] args);
 
   /**
    * Sets a hash field value.

--- a/fluxgate-redis-ratelimiter/src/main/java/org/fluxgate/redis/connection/StandaloneRedisConnection.java
+++ b/fluxgate-redis-ratelimiter/src/main/java/org/fluxgate/redis/connection/StandaloneRedisConnection.java
@@ -109,6 +109,16 @@ public class StandaloneRedisConnection implements RedisConnectionProvider {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
+  public <T> T eval(String script, String[] keys, String[] args) {
+    Objects.requireNonNull(script, "script must not be null");
+    Objects.requireNonNull(keys, "keys must not be null");
+    Objects.requireNonNull(args, "args must not be null");
+
+    return (T) commands.eval(script, ScriptOutputType.MULTI, keys, args);
+  }
+
+  @Override
   public boolean hset(String key, String field, String value) {
     return commands.hset(key, field, value);
   }

--- a/fluxgate-redis-ratelimiter/src/main/java/org/fluxgate/redis/store/RedisTokenBucketStore.java
+++ b/fluxgate-redis-ratelimiter/src/main/java/org/fluxgate/redis/store/RedisTokenBucketStore.java
@@ -1,7 +1,9 @@
 package org.fluxgate.redis.store;
 
+import io.lettuce.core.RedisNoScriptException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.fluxgate.core.config.RateLimitBand;
 import org.fluxgate.redis.connection.RedisConnectionProvider;
 import org.fluxgate.redis.script.LuaScriptLoader;
@@ -29,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public class RedisTokenBucketStore {
 
   private static final Logger log = LoggerFactory.getLogger(RedisTokenBucketStore.class);
-
+  private final AtomicBoolean reloadingLuaScript = new AtomicBoolean(false);
   private final RedisConnectionProvider connectionProvider;
 
   /**
@@ -94,12 +96,8 @@ public class RedisTokenBucketStore {
       String.valueOf(capacity), String.valueOf(windowNanos), String.valueOf(permits)
     };
 
-    // Get cached SHA from script loader
-    String sha = LuaScripts.getTokenBucketConsumeSha();
-
-    // Execute Lua script using EVALSHA (more efficient than EVAL)
-    // In cluster mode, Lettuce automatically routes to the correct node based on KEYS[1]
-    List<Long> result = connectionProvider.evalsha(sha, keys, args);
+    // Execute Lua script with NOSCRIPT fallback
+    List<Long> result = executeScriptWithFallback(keys, args);
 
     // Parse result: [consumed, remaining_tokens, nanos_to_wait, reset_time_millis]
     if (result == null || result.size() != 4) {
@@ -128,6 +126,69 @@ public class RedisTokenBucketStore {
           nanosToWait,
           resetTimeMillis);
       return BucketState.rejected(remainingTokens, nanosToWait, resetTimeMillis);
+    }
+  }
+
+  /**
+   * Executes the Lua script with NOSCRIPT error fallback.
+   *
+   * <p>This method handles the case where Redis has been restarted and the script cache is lost.
+   * When EVALSHA fails with NOSCRIPT error, it falls back to:
+   *
+   * <ol>
+   *   <li>Execute using EVAL (slower but works)
+   *   <li>Reload the script into Redis cache for future calls
+   * </ol>
+   *
+   * @param keys the keys for the script
+   * @param args the arguments for the script
+   * @return the script execution result
+   */
+  private List<Long> executeScriptWithFallback(String[] keys, String[] args) {
+    String sha = LuaScripts.getTokenBucketConsumeSha();
+    String script = LuaScripts.getTokenBucketConsumeScript();
+
+    try {
+      // Try EVALSHA first (efficient, uses cached script)
+      return connectionProvider.evalsha(sha, keys, args);
+    } catch (RedisNoScriptException e) {
+      // Script not in Redis cache (e.g., Redis was restarted)
+      log.warn(
+          "Lua script not found in Redis cache (NOSCRIPT). "
+              + "Falling back to EVAL and reloading script. SHA: {}",
+          sha);
+
+      // Fallback 1 - Execute using EVAL (slower but works immediately)
+      List<Long> result = connectionProvider.eval(script, keys, args);
+
+      // Fallback 2 - Reload script for future calls (thread-safe with AtomicBoolean)
+      reloadScript();
+
+      return result;
+    }
+  }
+
+  /**
+   * Reloads the Lua script into Redis cache.
+   *
+   * <p>This is called after a NOSCRIPT error to restore the script cache. Uses AtomicBoolean to
+   * prevent multiple concurrent reload attempts.
+   */
+  private void reloadScript() {
+    if (!reloadingLuaScript.compareAndSet(false, true)) {
+      log.debug("Lua script is already being reloaded, skipping...");
+      return;
+    }
+
+    try {
+      String script = LuaScripts.getTokenBucketConsumeScript();
+      String sha = connectionProvider.scriptLoad(script);
+      LuaScripts.setTokenBucketConsumeSha(sha);
+      log.info("Lua script reloaded into Redis. SHA: {}", sha);
+    } catch (Exception e) {
+      log.error("Failed to reload Lua script: {}", e.getMessage(), e);
+    } finally {
+      reloadingLuaScript.set(false);
     }
   }
 

--- a/fluxgate-redis-ratelimiter/src/test/java/org/fluxgate/redis/store/RedisTokenBucketStoreMockTest.java
+++ b/fluxgate-redis-ratelimiter/src/test/java/org/fluxgate/redis/store/RedisTokenBucketStoreMockTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import io.lettuce.core.RedisNoScriptException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -14,6 +15,7 @@ import org.fluxgate.redis.connection.RedisConnectionProvider.RedisMode;
 import org.fluxgate.redis.script.LuaScripts;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -206,5 +208,113 @@ class RedisTokenBucketStoreMockTest {
 
     // then
     assertThat(store.getMode()).isEqualTo(RedisMode.CLUSTER);
+  }
+
+  @Test
+  @DisplayName("NOSCRIPT error should fallback to EVAL and reload script")
+  void shouldFallbackToEvalOnNoscriptError() {
+    // given
+    RateLimitBand band = RateLimitBand.builder(Duration.ofSeconds(60), 100).label("test").build();
+
+    // First call throws NOSCRIPT error
+    doThrow(new RedisNoScriptException("NOSCRIPT No matching script"))
+        .when(connectionProvider)
+        .evalsha(anyString(), any(String[].class), any(String[].class));
+
+    // EVAL fallback should work
+    List<Long> scriptResult = Arrays.asList(1L, 99L, 0L, System.currentTimeMillis());
+    doReturn(scriptResult)
+        .when(connectionProvider)
+        .eval(anyString(), any(String[].class), any(String[].class));
+
+    // Script reload should return new SHA
+    doReturn("new-sha-456").when(connectionProvider).scriptLoad(anyString());
+
+    // when
+    BucketState result = store.tryConsume("test-key", band, 1);
+
+    // then
+    assertThat(result.consumed()).isTrue();
+    assertThat(result.remainingTokens()).isEqualTo(99);
+
+    // Verify EVAL was called as fallback
+    verify(connectionProvider).eval(eq("test-script"), any(String[].class), any(String[].class));
+
+    // Verify script was reloaded
+    verify(connectionProvider).scriptLoad("test-script");
+
+    // Verify SHA was updated
+    assertThat(LuaScripts.getTokenBucketConsumeSha()).isEqualTo("new-sha-456");
+  }
+
+  @Test
+  @DisplayName("NOSCRIPT recovery should work for subsequent calls")
+  void shouldRecoverFromNoscriptError() {
+    // given
+    RateLimitBand band = RateLimitBand.builder(Duration.ofSeconds(60), 100).label("test").build();
+
+    List<Long> scriptResult = Arrays.asList(1L, 99L, 0L, System.currentTimeMillis());
+
+    // First call: NOSCRIPT error → fallback to EVAL
+    doThrow(new RedisNoScriptException("NOSCRIPT No matching script"))
+        .doReturn(scriptResult) // Second call succeeds
+        .when(connectionProvider)
+        .evalsha(anyString(), any(String[].class), any(String[].class));
+
+    doReturn(scriptResult)
+        .when(connectionProvider)
+        .eval(anyString(), any(String[].class), any(String[].class));
+
+    doReturn("new-sha-456").when(connectionProvider).scriptLoad(anyString());
+
+    // when - first call (triggers NOSCRIPT)
+    BucketState result1 = store.tryConsume("test-key", band, 1);
+
+    // Reset mock to simulate script being reloaded
+    reset(connectionProvider);
+    when(connectionProvider.getMode()).thenReturn(RedisMode.STANDALONE);
+    doReturn(scriptResult)
+        .when(connectionProvider)
+        .evalsha(anyString(), any(String[].class), any(String[].class));
+
+    // when - second call (should use reloaded script)
+    BucketState result2 = store.tryConsume("test-key", band, 1);
+
+    // then
+    assertThat(result1.consumed()).isTrue();
+    assertThat(result2.consumed()).isTrue();
+
+    // EVAL should not be called on second request (script was reloaded)
+    verify(connectionProvider, never()).eval(anyString(), any(String[].class), any(String[].class));
+  }
+
+  @Test
+  @DisplayName("Script reload failure should not break EVAL fallback")
+  void shouldContinueWorkingEvenIfReloadFails() {
+    // given
+    RateLimitBand band = RateLimitBand.builder(Duration.ofSeconds(60), 100).label("test").build();
+
+    // EVALSHA throws NOSCRIPT
+    doThrow(new RedisNoScriptException("NOSCRIPT No matching script"))
+        .when(connectionProvider)
+        .evalsha(anyString(), any(String[].class), any(String[].class));
+
+    // EVAL works
+    List<Long> scriptResult = Arrays.asList(1L, 99L, 0L, System.currentTimeMillis());
+    doReturn(scriptResult)
+        .when(connectionProvider)
+        .eval(anyString(), any(String[].class), any(String[].class));
+
+    // Script reload fails
+    doThrow(new RuntimeException("Redis connection lost"))
+        .when(connectionProvider)
+        .scriptLoad(anyString());
+
+    // when - should not throw even though reload failed
+    BucketState result = store.tryConsume("test-key", band, 1);
+
+    // then - EVAL fallback should still work
+    assertThat(result.consumed()).isTrue();
+    assertThat(result.remainingTokens()).isEqualTo(99);
   }
 }

--- a/fluxgate-spring-boot2-starter/src/main/java/org/fluxgate/spring/reload/strategy/PollingReloadStrategy.java
+++ b/fluxgate-spring-boot2-starter/src/main/java/org/fluxgate/spring/reload/strategy/PollingReloadStrategy.java
@@ -187,13 +187,7 @@ public class PollingReloadStrategy extends AbstractReloadStrategy {
    * @return version hash
    */
   private int computeVersion(RateLimitRuleSet ruleSet) {
-    // Use a combination of ID, description, and rules hash
-    int hash = ruleSet.getId().hashCode();
-    if (ruleSet.getDescription() != null) {
-      hash = 31 * hash + ruleSet.getDescription().hashCode();
-    }
-    hash = 31 * hash + ruleSet.getRules().hashCode();
-    return hash;
+    return Objects.hash(ruleSet.getId(), ruleSet.getDescription(), ruleSet.getRules());
   }
 
   /**

--- a/fluxgate-spring-boot3-starter/src/main/java/org/fluxgate/spring/reload/strategy/PollingReloadStrategy.java
+++ b/fluxgate-spring-boot3-starter/src/main/java/org/fluxgate/spring/reload/strategy/PollingReloadStrategy.java
@@ -187,13 +187,7 @@ public class PollingReloadStrategy extends AbstractReloadStrategy {
    * @return version hash
    */
   private int computeVersion(RateLimitRuleSet ruleSet) {
-    // Use a combination of ID, description, and rules hash
-    int hash = ruleSet.getId().hashCode();
-    if (ruleSet.getDescription() != null) {
-      hash = 31 * hash + ruleSet.getDescription().hashCode();
-    }
-    hash = 31 * hash + ruleSet.getRules().hashCode();
-    return hash;
+    return Objects.hash(ruleSet.getId(), ruleSet.getDescription(), ruleSet.getRules());
   }
 
   /**


### PR DESCRIPTION
  When Redis restarts, cached Lua scripts are lost causing NOSCRIPT errors.